### PR TITLE
Feat: 로그인페이지 뷰#8

### DIFF
--- a/FindDict/FindDict.xcodeproj/project.pbxproj
+++ b/FindDict/FindDict.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		4DBDEC2C28D4F169002252B3 /* BaseVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBDEC2B28D4F169002252B3 /* BaseVC.swift */; };
 		4DBDEC2F28D4F2B3002252B3 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBDEC2E28D4F2B3002252B3 /* UIViewController+.swift */; };
 		4DBDEC3228D4F308002252B3 /* Colorsets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4DBDEC3128D4F308002252B3 /* Colorsets.xcassets */; };
+		F8823AA128DFE99200798374 /* SignUpVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8823AA028DFE99200798374 /* SignUpVC.swift */; };
+		F8823AA328E022CC00798374 /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8823AA228E022CC00798374 /* UITextField+.swift */; };
 		F8DB7A5A28DB1D3100EE3D66 /* SignInVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DB7A5928DB1D3100EE3D66 /* SignInVC.swift */; };
 		F8DB7A5C28DB1FA700EE3D66 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DB7A5B28DB1FA700EE3D66 /* UIView+.swift */; };
 		F8DB7A5E28DB29F700EE3D66 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DB7A5D28DB29F700EE3D66 /* UIColor+.swift */; };
@@ -36,6 +38,8 @@
 		4DBDEC2B28D4F169002252B3 /* BaseVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseVC.swift; sourceTree = "<group>"; };
 		4DBDEC2E28D4F2B3002252B3 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		4DBDEC3128D4F308002252B3 /* Colorsets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colorsets.xcassets; sourceTree = "<group>"; };
+		F8823AA028DFE99200798374 /* SignUpVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpVC.swift; sourceTree = "<group>"; };
+		F8823AA228E022CC00798374 /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
 		F8DB7A5928DB1D3100EE3D66 /* SignInVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInVC.swift; sourceTree = "<group>"; };
 		F8DB7A5B28DB1FA700EE3D66 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		F8DB7A5D28DB29F700EE3D66 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
@@ -127,6 +131,7 @@
 				4DBDEC2E28D4F2B3002252B3 /* UIViewController+.swift */,
 				F8DB7A5B28DB1FA700EE3D66 /* UIView+.swift */,
 				F8DB7A5D28DB29F700EE3D66 /* UIColor+.swift */,
+				F8823AA228E022CC00798374 /* UITextField+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -157,6 +162,7 @@
 		4DBDEC3528D4F35D002252B3 /* Scences */ = {
 			isa = PBXGroup;
 			children = (
+				F8823A9F28DFE96200798374 /* SignUp */,
 				F8DB7A5628DB1C7900EE3D66 /* SignIn */,
 				4DBDEC1728D4EFE2002252B3 /* ViewController.swift */,
 				4DBDEC1928D4EFE2002252B3 /* Main.storyboard */,
@@ -170,6 +176,14 @@
 			children = (
 			);
 			path = Network;
+			sourceTree = "<group>";
+		};
+		F8823A9F28DFE96200798374 /* SignUp */ = {
+			isa = PBXGroup;
+			children = (
+				F8823AA028DFE99200798374 /* SignUpVC.swift */,
+			);
+			path = SignUp;
 			sourceTree = "<group>";
 		};
 		F8DB7A5628DB1C7900EE3D66 /* SignIn */ = {
@@ -268,7 +282,9 @@
 				F8DB7A5A28DB1D3100EE3D66 /* SignInVC.swift in Sources */,
 				4DBDEC2F28D4F2B3002252B3 /* UIViewController+.swift in Sources */,
 				4DBDEC1628D4EFE2002252B3 /* SceneDelegate.swift in Sources */,
+				F8823AA128DFE99200798374 /* SignUpVC.swift in Sources */,
 				4DBDEC2C28D4F169002252B3 /* BaseVC.swift in Sources */,
+				F8823AA328E022CC00798374 /* UITextField+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -415,7 +431,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = T24N5ZR2DS;
+				DEVELOPMENT_TEAM = 3BJK5D777T;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FindDict/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Find DIct";
@@ -446,7 +462,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = T24N5ZR2DS;
+				DEVELOPMENT_TEAM = 3BJK5D777T;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FindDict/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Find DIct";

--- a/FindDict/FindDict/Application/SceneDelegate.swift
+++ b/FindDict/FindDict/Application/SceneDelegate.swift
@@ -20,7 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = SignInVC()
+        window?.rootViewController = SignUpVC()
         window?.makeKeyAndVisible()
     }
 

--- a/FindDict/FindDict/Global/Base/AuthBaseVC.swift
+++ b/FindDict/FindDict/Global/Base/AuthBaseVC.swift
@@ -11,17 +11,17 @@ import Then
 
 class AuthBaseVC: UIViewController {
     
-    // 로고
+    // MARK: - Properties
     private let logoImage = UIImageView().then{
         $0.image = UIImage(named: "authImage")
     }
-    // 흰색 배경
     internal let containerView = UIView().then{
         $0.backgroundColor = .white
         $0.layer.cornerRadius = 24
 
     }
-
+    
+    // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
         setLayout()
@@ -32,6 +32,8 @@ class AuthBaseVC: UIViewController {
 
 }
 
+
+// MARK: - UI
 extension AuthBaseVC {
     private func setLayout(){
         view.addSubViews([logoImage, containerView])

--- a/FindDict/FindDict/Global/Base/AuthBaseVC.swift
+++ b/FindDict/FindDict/Global/Base/AuthBaseVC.swift
@@ -6,6 +6,8 @@
 //
 
 import UIKit
+import SnapKit
+import Then
 
 class AuthBaseVC: UIViewController {
     
@@ -14,11 +16,11 @@ class AuthBaseVC: UIViewController {
         $0.image = UIImage(named: "authImage")
     }
     // 흰색 배경
-    private let containerView = UIView().then{
+    internal let containerView = UIView().then{
         $0.backgroundColor = .white
+        $0.layer.cornerRadius = 24
+
     }
-        // 텍스트 필드 -> component
-        // 회원가입하기, 로그인 버튼
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -32,6 +34,15 @@ class AuthBaseVC: UIViewController {
 
 extension AuthBaseVC {
     private func setLayout(){
-        view.addSubViews([logoImage, bgView])
+        view.addSubViews([logoImage, containerView])
+        
+        logoImage.snp.makeConstraints{
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(100)
+            $0.centerX.equalTo(view.safeAreaLayoutGuide)
+        }
+        containerView.snp.makeConstraints{
+            $0.top.equalTo(logoImage.snp.bottom).offset(70)
+            
+        }
     }
 }

--- a/FindDict/FindDict/Global/Extensions/UIColor+.swift
+++ b/FindDict/FindDict/Global/Extensions/UIColor+.swift
@@ -23,5 +23,8 @@ extension UIColor {
   @nonobjc class var buttonYellow: UIColor {
     return UIColor(red: 248.0 / 255.0, green: 213.0 / 255.0, blue: 72.0 / 255.0, alpha: 1.0)
   }
+  @nonobjc class var textFieldGray: UIColor {
+      return UIColor(red: 232.0 / 255.0, green: 232.0 / 255.0, blue: 232.0 / 255.0, alpha: 1.0)
+    }
 
 }

--- a/FindDict/FindDict/Global/Extensions/UITextField+.swift
+++ b/FindDict/FindDict/Global/Extensions/UITextField+.swift
@@ -1,0 +1,25 @@
+//
+//  UITextField+.swift
+//  FindDict
+//
+//  Created by kyung lin kim on 2022/09/25.
+//
+
+import UIKit
+
+extension UITextField {
+        
+    /// UITextField 왼쪽에 여백 주는 메서드
+    func addLeftPadding(_ amount: CGFloat) {
+        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: amount, height: self.frame.size.height))
+        self.leftView = paddingView
+        self.leftViewMode = .always
+    }
+    
+    /// UITextField 오른쪽에 여백 주는 메서드
+    func addRightPadding(_ amount: CGFloat) {
+        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: amount, height: self.frame.size.height))
+        self.rightView = paddingView
+        self.rightViewMode = .always
+    }
+}

--- a/FindDict/FindDict/Sources/Scences/SignUp/SignUpVC.swift
+++ b/FindDict/FindDict/Sources/Scences/SignUp/SignUpVC.swift
@@ -52,7 +52,7 @@ class SignUpVC: AuthBaseVC {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setLayOut()
+        setLayout()
         
     }
     
@@ -61,7 +61,7 @@ class SignUpVC: AuthBaseVC {
 }
 
 extension SignUpVC {
-    private func setLayOut(){
+    private func setLayout(){
         view.addSubViews([idTextField,idCheckButton,ageText, passwordText, passwordConfirmText, signUpButton])
     
     containerView.snp.makeConstraints{

--- a/FindDict/FindDict/Sources/Scences/SignUp/SignUpVC.swift
+++ b/FindDict/FindDict/Sources/Scences/SignUp/SignUpVC.swift
@@ -11,7 +11,7 @@ import Then
 
 class SignUpVC: AuthBaseVC {
 
-    private let idText = UITextField().then{
+    private let idTextField = UITextField().then{
         $0.backgroundColor = .textFieldGray
         $0.placeholder = "아이디"
         $0.layer.cornerRadius = 11
@@ -62,7 +62,7 @@ class SignUpVC: AuthBaseVC {
 
 extension SignUpVC {
     private func setLayOut(){
-        view.addSubViews([idText,idCheckButton,ageText, passwordText, passwordConfirmText, signUpButton])
+        view.addSubViews([idTextField,idCheckButton,ageText, passwordText, passwordConfirmText, signUpButton])
     
     containerView.snp.makeConstraints{
         $0.leading.equalTo(view.safeAreaLayoutGuide.snp.leading).offset(317)
@@ -70,7 +70,7 @@ extension SignUpVC {
         $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(151)
     }
     
-        idText.snp.makeConstraints{
+        idTextField.snp.makeConstraints{
             $0.top.equalTo(containerView.snp.top).offset(45)
             $0.leading.equalTo(containerView.snp.leading).offset(88)
             $0.trailing.equalTo(containerView.snp.trailing).offset(-208)
@@ -78,13 +78,13 @@ extension SignUpVC {
         }
         idCheckButton.snp.makeConstraints{
                 $0.top.equalTo(containerView.snp.top).offset(45)
-                $0.bottom.equalTo(idText.snp.bottom).offset(0)
-                $0.leading.equalTo(idText.snp.trailing).offset(18)
+                $0.bottom.equalTo(idTextField.snp.bottom).offset(0)
+                $0.leading.equalTo(idTextField.snp.trailing).offset(18)
                 $0.trailing.equalTo(containerView.snp.trailing).offset(-88)
             
         }
         ageText.snp.makeConstraints{
-                $0.top.equalTo(idText.snp.bottom).offset(18)
+                $0.top.equalTo(idTextField.snp.bottom).offset(18)
                 $0.leading.equalTo(containerView.snp.leading).offset(88)
                 $0.trailing.equalTo(containerView.snp.trailing).offset(-88)
             $0.height.equalTo(50)

--- a/FindDict/FindDict/Sources/Scences/SignUp/SignUpVC.swift
+++ b/FindDict/FindDict/Sources/Scences/SignUp/SignUpVC.swift
@@ -1,0 +1,112 @@
+//
+//  SignUpVC.swift
+//  FindDict
+//
+//  Created by kyung lin kim on 2022/09/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+class SignUpVC: AuthBaseVC {
+
+    private let idText = UITextField().then{
+        $0.backgroundColor = .textFieldGray
+        $0.placeholder = "아이디"
+        $0.layer.cornerRadius = 11
+        $0.addLeftPadding(10)
+    }
+    private let idCheckButton = UIButton().then{
+        $0.backgroundColor = .buttonOrange
+        $0.setTitleColor(.black, for: .normal)
+        $0.setTitle("중복 확인", for: .normal)
+        $0.layer.cornerRadius = 24
+    }
+    private let ageText = UITextField().then{
+        $0.backgroundColor = .textFieldGray
+        $0.placeholder = "나이"
+        $0.layer.cornerRadius = 11
+        $0.addLeftPadding(10)
+    }
+    private let passwordText = UITextField().then{
+        $0.backgroundColor = .textFieldGray
+        $0.placeholder = "비밀번호"
+        $0.layer.cornerRadius = 11
+        $0.addLeftPadding(10)
+    }
+    private let passwordConfirmText = UITextField().then{
+        $0.backgroundColor = .textFieldGray
+        $0.placeholder = "비밀번호 확인"
+        $0.layer.cornerRadius = 11
+        $0.addLeftPadding(10)
+    }
+    private let signUpButton = UIButton().then{
+        $0.backgroundColor = .buttonYellow
+        $0.setTitleColor(.black, for: .normal)
+        $0.setTitle("회원가입하기", for: .normal)
+        $0.layer.cornerRadius = 24
+        
+    }
+    
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setLayOut()
+        
+    }
+    
+
+
+}
+
+extension SignUpVC {
+    private func setLayOut(){
+        view.addSubViews([idText,idCheckButton,ageText, passwordText, passwordConfirmText, signUpButton])
+    
+    containerView.snp.makeConstraints{
+        $0.leading.equalTo(view.safeAreaLayoutGuide.snp.leading).offset(317)
+        $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).offset(-317)
+        $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(151)
+    }
+    
+        idText.snp.makeConstraints{
+            $0.top.equalTo(containerView.snp.top).offset(45)
+            $0.leading.equalTo(containerView.snp.leading).offset(88)
+            $0.trailing.equalTo(containerView.snp.trailing).offset(-208)
+            $0.height.equalTo(50)
+        }
+        idCheckButton.snp.makeConstraints{
+                $0.top.equalTo(containerView.snp.top).offset(45)
+                $0.bottom.equalTo(idText.snp.bottom).offset(0)
+                $0.leading.equalTo(idText.snp.trailing).offset(18)
+                $0.trailing.equalTo(containerView.snp.trailing).offset(-88)
+            
+        }
+        ageText.snp.makeConstraints{
+                $0.top.equalTo(idText.snp.bottom).offset(18)
+                $0.leading.equalTo(containerView.snp.leading).offset(88)
+                $0.trailing.equalTo(containerView.snp.trailing).offset(-88)
+            $0.height.equalTo(50)
+        }
+
+        passwordText.snp.makeConstraints{
+                $0.top.equalTo(ageText.snp.bottom).offset(18)
+                $0.leading.equalTo(containerView.snp.leading).offset(88)
+                $0.trailing.equalTo(containerView.snp.trailing).offset(-88)
+            $0.height.equalTo(50)
+        }
+        passwordConfirmText.snp.makeConstraints{
+                $0.top.equalTo(passwordText.snp.bottom).offset(18)
+                $0.leading.equalTo(containerView.snp.leading).offset(88)
+                $0.trailing.equalTo(containerView.snp.trailing).offset(-88)
+            $0.height.equalTo(50)
+        }
+        signUpButton.snp.makeConstraints{
+                $0.top.equalTo(passwordConfirmText.snp.bottom).offset(21)
+                $0.leading.equalTo(containerView.snp.leading).offset(137)
+                $0.trailing.equalTo(containerView.snp.trailing).offset(-137)
+            $0.height.equalTo(56)
+        }
+    }
+}


### PR DESCRIPTION
## 작업한 내용
- AuthBaseVC를 만들어서 로그인과 회원가입 뷰에 공통되는 요소들을 넣어줌
- SignUpVC에서 AuthBaseVC를 상속받아 나머지 텍스트 필드 추가
- Extensions에 UITextField+를 추가하여 텍스트 필드 왼쪽에 여백 추가

## PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
-  AuthBaseVC의 containerView는 SignUpVC에서 오버라이드되기 때문에 private으로 정의할 수 없다. 따라서 protected로 접근 제어자를 설정하려했으나 swift에서는 protected가 존재하지 않는다. 그 대신 *internal*이라는 새로운 접근제어자를 발견했습니다!
> internal is the only access modifier between fileprivate and public
같은 모듈 내에서 접근 권한이 생긴다고합니다! 


## 📸 스크린샷
<!-- gif or mp4 용량 제한 있음 -->
![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2022-09-25 at 15 20 41](https://user-images.githubusercontent.com/72034311/192131078-440dbcb3-2306-407a-80bd-b6f1257c6714.png)


## 관련 이슈
- Resolved: #8 

<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->