### PR TITLE
[FEAT] 게임 로직 구현

### DIFF
--- a/FindDict/FindDict.xcodeproj/project.pbxproj
+++ b/FindDict/FindDict.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		4DBDEC2C28D4F169002252B3 /* BaseVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBDEC2B28D4F169002252B3 /* BaseVC.swift */; };
 		4DBDEC2F28D4F2B3002252B3 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBDEC2E28D4F2B3002252B3 /* UIViewController+.swift */; };
 		4DBDEC3228D4F308002252B3 /* Colorsets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4DBDEC3128D4F308002252B3 /* Colorsets.xcassets */; };
+		4DF76EB8290A61FF00AA79D2 /* GameResultButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF76EB7290A61FF00AA79D2 /* GameResultButton.swift */; };
+		4DF76EBC290A680F00AA79D2 /* TargetListComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF76EBB290A680F00AA79D2 /* TargetListComponentView.swift */; };
 		F82979B728ED5C030031BBC3 /* ModalBaseVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82979B628ED5C030031BBC3 /* ModalBaseVC.swift */; };
 		F82979BF28EEB2220031BBC3 /* GameResultSuccessVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82979BE28EEB2220031BBC3 /* GameResultSuccessVC.swift */; };
 		F82979C128EEC3A40031BBC3 /* GameResultFailVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82979C028EEC3A40031BBC3 /* GameResultFailVC.swift */; };
@@ -78,6 +80,8 @@
 		4DBDEC2B28D4F169002252B3 /* BaseVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseVC.swift; sourceTree = "<group>"; };
 		4DBDEC2E28D4F2B3002252B3 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		4DBDEC3128D4F308002252B3 /* Colorsets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colorsets.xcassets; sourceTree = "<group>"; };
+		4DF76EB7290A61FF00AA79D2 /* GameResultButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GameResultButton.swift; sourceTree = "<group>"; };
+		4DF76EBB290A680F00AA79D2 /* TargetListComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetListComponentView.swift; sourceTree = "<group>"; };
 		F82979B628ED5C030031BBC3 /* ModalBaseVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalBaseVC.swift; sourceTree = "<group>"; };
 		F82979BE28EEB2220031BBC3 /* GameResultSuccessVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameResultSuccessVC.swift; sourceTree = "<group>"; };
 		F82979C028EEC3A40031BBC3 /* GameResultFailVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameResultFailVC.swift; sourceTree = "<group>"; };
@@ -126,6 +130,7 @@
 				4D8E9F3228F001C00013B7E7 /* yolov7.mlmodel */,
 				4D0B1E1328E5AA2C007F16DB /* yolov5m.mlmodel */,
 				4D0B1E1128E5A9A4007F16DB /* ObjectDetection.swift */,
+				4DF76EBB290A680F00AA79D2 /* TargetListComponentView.swift */,
 				4D0B1E1728E6D5BA007F16DB /* DrawingBoundingBoxView.swift */,
 				F82979BD28EEB1ED0031BBC3 /* GameResultModal */,
 			);
@@ -239,6 +244,7 @@
 			children = (
 				F8823AA828E575D300798374 /* MainButton.swift */,
 				4D14BD6928E1C0F9002B2165 /* TextField.swift */,
+				4DF76EB7290A61FF00AA79D2 /* GameResultButton.swift */,
 				4D14BD7028E206BA002B2165 /* PhotoSelectorButton.swift */,
 			);
 			path = Components;
@@ -378,6 +384,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4D0B1E1428E5AA2C007F16DB /* yolov5m.mlmodel in Sources */,
+				4DF76EBC290A680F00AA79D2 /* TargetListComponentView.swift in Sources */,
 				4D0B1E1628E5B213007F16DB /* UIImage+.swift in Sources */,
 				4D8E9F3328F001C00013B7E7 /* yolov7.mlmodel in Sources */,
 				4DBDEC1828D4EFE2002252B3 /* ViewController.swift in Sources */,
@@ -387,6 +394,7 @@
 				F8823AA728E5740F00798374 /* mainVC.swift in Sources */,
 				F860B7A328E835860032A39B /* DictionaryCard.swift in Sources */,
 				4DBDEC1428D4EFE2002252B3 /* AppDelegate.swift in Sources */,
+				4DF76EB8290A61FF00AA79D2 /* GameResultButton.swift in Sources */,
 				4D14BD6A28E1C0F9002B2165 /* TextField.swift in Sources */,
 				F8DB7A6028DB2E8600EE3D66 /* AuthBaseVC.swift in Sources */,
 				4D0B1E1228E5A9A4007F16DB /* ObjectDetection.swift in Sources */,
@@ -559,7 +567,7 @@
 				DEVELOPMENT_TEAM = T24N5ZR2DS;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FindDict/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "Find DIct";
+				INFOPLIST_KEY_CFBundleDisplayName = "Find Dict";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.education";
 				INFOPLIST_KEY_NSCameraUsageDescription = "카메라로 사진 찍기";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "앨범에서 사진 선택";
@@ -592,7 +600,7 @@
 				DEVELOPMENT_TEAM = T24N5ZR2DS;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FindDict/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "Find DIct";
+				INFOPLIST_KEY_CFBundleDisplayName = "Find Dict";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.education";
 				INFOPLIST_KEY_NSCameraUsageDescription = "카메라로 사진 찍기";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "앨범에서 사진 선택";

--- a/FindDict/FindDict.xcodeproj/project.pbxproj
+++ b/FindDict/FindDict.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		4D0B1E1028E59178007F16DB /* NotoSans-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4D14BD7328E20A8C002B2165 /* NotoSans-Bold.ttf */; };
-		4D0B1E1228E5A9A4007F16DB /* ObjectDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D0B1E1128E5A9A4007F16DB /* ObjectDetection.swift */; };
+		4D0B1E1228E5A9A4007F16DB /* GameVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D0B1E1128E5A9A4007F16DB /* GameVC.swift */; };
 		4D0B1E1428E5AA2C007F16DB /* yolov5m.mlmodel in Sources */ = {isa = PBXBuildFile; fileRef = 4D0B1E1328E5AA2C007F16DB /* yolov5m.mlmodel */; };
 		4D0B1E1628E5B213007F16DB /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D0B1E1528E5B213007F16DB /* UIImage+.swift */; };
 		4D0B1E1828E6D5BA007F16DB /* DrawingBoundingBoxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D0B1E1728E6D5BA007F16DB /* DrawingBoundingBoxView.swift */; };
@@ -55,7 +55,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		4D0B1E1128E5A9A4007F16DB /* ObjectDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectDetection.swift; sourceTree = "<group>"; };
+		4D0B1E1128E5A9A4007F16DB /* GameVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameVC.swift; sourceTree = "<group>"; };
 		4D0B1E1328E5AA2C007F16DB /* yolov5m.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; name = yolov5m.mlmodel; path = "../../../../../../../2022/2022-2/캡스톤 디자인/mlmodel/yolov5m.mlmodel"; sourceTree = "<group>"; };
 		4D0B1E1528E5B213007F16DB /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		4D0B1E1728E6D5BA007F16DB /* DrawingBoundingBoxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingBoundingBoxView.swift; sourceTree = "<group>"; };
@@ -131,7 +131,7 @@
 				4D14BD6E28E2068B002B2165 /* PhotoSelectorVC.swift */,
 				4D8E9F3228F001C00013B7E7 /* yolov7.mlmodel */,
 				4D0B1E1328E5AA2C007F16DB /* yolov5m.mlmodel */,
-				4D0B1E1128E5A9A4007F16DB /* ObjectDetection.swift */,
+				4D0B1E1128E5A9A4007F16DB /* GameVC.swift */,
 				4DF76EBB290A680F00AA79D2 /* TargetListComponentView.swift */,
 				4D0B1E1728E6D5BA007F16DB /* DrawingBoundingBoxView.swift */,
 				F82979BD28EEB1ED0031BBC3 /* GameResultModal */,
@@ -400,7 +400,7 @@
 				4DF76EB8290A61FF00AA79D2 /* GameResultButton.swift in Sources */,
 				4D14BD6A28E1C0F9002B2165 /* TextField.swift in Sources */,
 				F8DB7A6028DB2E8600EE3D66 /* AuthBaseVC.swift in Sources */,
-				4D0B1E1228E5A9A4007F16DB /* ObjectDetection.swift in Sources */,
+				4D0B1E1228E5A9A4007F16DB /* GameVC.swift in Sources */,
 				F8DB7A5C28DB1FA700EE3D66 /* UIView+.swift in Sources */,
 				4D14BD6F28E2068B002B2165 /* PhotoSelectorVC.swift in Sources */,
 				F860B79F28E7D0AB0032A39B /* DictionaryTVC.swift in Sources */,

--- a/FindDict/FindDict.xcodeproj/project.pbxproj
+++ b/FindDict/FindDict.xcodeproj/project.pbxproj
@@ -46,7 +46,7 @@
 		F860B7A528E84F5D0032A39B /* WordDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F860B7A428E84F5D0032A39B /* WordDataModel.swift */; };
 		F8823AA128DFE99200798374 /* SignUpVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8823AA028DFE99200798374 /* SignUpVC.swift */; };
 		F8823AA328E022CC00798374 /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8823AA228E022CC00798374 /* UITextField+.swift */; };
-		F8823AA728E5740F00798374 /* mainVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8823AA628E5740F00798374 /* mainVC.swift */; };
+		F8823AA728E5740F00798374 /* MainVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8823AA628E5740F00798374 /* MainVC.swift */; };
 		F8823AA928E575D300798374 /* MainButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8823AA828E575D300798374 /* MainButton.swift */; };
 		F8DB7A5A28DB1D3100EE3D66 /* BeforeSignInVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DB7A5928DB1D3100EE3D66 /* BeforeSignInVC.swift */; };
 		F8DB7A5C28DB1FA700EE3D66 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DB7A5B28DB1FA700EE3D66 /* UIView+.swift */; };
@@ -94,7 +94,7 @@
 		F860B7A428E84F5D0032A39B /* WordDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordDataModel.swift; sourceTree = "<group>"; };
 		F8823AA028DFE99200798374 /* SignUpVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpVC.swift; sourceTree = "<group>"; };
 		F8823AA228E022CC00798374 /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
-		F8823AA628E5740F00798374 /* mainVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = mainVC.swift; sourceTree = "<group>"; };
+		F8823AA628E5740F00798374 /* MainVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainVC.swift; sourceTree = "<group>"; };
 		F8823AA828E575D300798374 /* MainButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainButton.swift; sourceTree = "<group>"; };
 		F8DB7A5928DB1D3100EE3D66 /* BeforeSignInVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeforeSignInVC.swift; sourceTree = "<group>"; };
 		F8DB7A5B28DB1FA700EE3D66 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
@@ -297,7 +297,7 @@
 		F8823AAA28E590E400798374 /* Main */ = {
 			isa = PBXGroup;
 			children = (
-				F8823AA628E5740F00798374 /* mainVC.swift */,
+				F8823AA628E5740F00798374 /* MainVC.swift */,
 			);
 			path = Main;
 			sourceTree = "<group>";
@@ -394,7 +394,7 @@
 				4D14BD7728E20B8D002B2165 /* UIFont+.swift in Sources */,
 				F8DB7A5E28DB29F700EE3D66 /* UIColor+.swift in Sources */,
 				F82979C128EEC3A40031BBC3 /* GameResultFailVC.swift in Sources */,
-				F8823AA728E5740F00798374 /* mainVC.swift in Sources */,
+				F8823AA728E5740F00798374 /* MainVC.swift in Sources */,
 				F860B7A328E835860032A39B /* DictionaryCard.swift in Sources */,
 				4DBDEC1428D4EFE2002252B3 /* AppDelegate.swift in Sources */,
 				4DF76EB8290A61FF00AA79D2 /* GameResultButton.swift in Sources */,

--- a/FindDict/FindDict.xcodeproj/project.pbxproj
+++ b/FindDict/FindDict.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		4DBDEC2C28D4F169002252B3 /* BaseVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBDEC2B28D4F169002252B3 /* BaseVC.swift */; };
 		4DBDEC2F28D4F2B3002252B3 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBDEC2E28D4F2B3002252B3 /* UIViewController+.swift */; };
 		4DBDEC3228D4F308002252B3 /* Colorsets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4DBDEC3128D4F308002252B3 /* Colorsets.xcassets */; };
+		4DEE7166290F53EE000C5D9A /* WordDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DEE7165290F53EE000C5D9A /* WordDictionary.swift */; };
 		4DF76EB8290A61FF00AA79D2 /* GameResultButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF76EB7290A61FF00AA79D2 /* GameResultButton.swift */; };
 		4DF76EBC290A680F00AA79D2 /* TargetListComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF76EBB290A680F00AA79D2 /* TargetListComponentView.swift */; };
 		F82979B728ED5C030031BBC3 /* ModalBaseVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82979B628ED5C030031BBC3 /* ModalBaseVC.swift */; };
@@ -80,6 +81,7 @@
 		4DBDEC2B28D4F169002252B3 /* BaseVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseVC.swift; sourceTree = "<group>"; };
 		4DBDEC2E28D4F2B3002252B3 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		4DBDEC3128D4F308002252B3 /* Colorsets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colorsets.xcassets; sourceTree = "<group>"; };
+		4DEE7165290F53EE000C5D9A /* WordDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordDictionary.swift; sourceTree = "<group>"; };
 		4DF76EB7290A61FF00AA79D2 /* GameResultButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GameResultButton.swift; sourceTree = "<group>"; };
 		4DF76EBB290A680F00AA79D2 /* TargetListComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetListComponentView.swift; sourceTree = "<group>"; };
 		F82979B628ED5C030031BBC3 /* ModalBaseVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalBaseVC.swift; sourceTree = "<group>"; };
@@ -190,6 +192,7 @@
 				4DBDEC3328D4F32F002252B3 /* Fonts */,
 				4DBDEC1C28D4EFE3002252B3 /* Assets.xcassets */,
 				4DBDEC3128D4F308002252B3 /* Colorsets.xcassets */,
+				4DEE7165290F53EE000C5D9A /* WordDictionary.swift */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -408,6 +411,7 @@
 				4DBDEC2F28D4F2B3002252B3 /* UIViewController+.swift in Sources */,
 				F82979B728ED5C030031BBC3 /* ModalBaseVC.swift in Sources */,
 				F860B7A528E84F5D0032A39B /* WordDataModel.swift in Sources */,
+				4DEE7166290F53EE000C5D9A /* WordDictionary.swift in Sources */,
 				4D14BD6828E1B924002B2165 /* UIButton+.swift in Sources */,
 				F860B7A128E832DB0032A39B /* UITableViewCell+.swift in Sources */,
 				4DBDEC1628D4EFE2002252B3 /* SceneDelegate.swift in Sources */,

--- a/FindDict/FindDict.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FindDict/FindDict.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -12,7 +12,7 @@
     {
       "identity" : "then",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/devxoul/Then.git",
+      "location" : "https://github.com/devxoul/Then",
       "state" : {
         "branch" : "master",
         "revision" : "d41ef523faef0f911369f79c0b96815d9dbb6d7a"

--- a/FindDict/FindDict/Application/SceneDelegate.swift
+++ b/FindDict/FindDict/Application/SceneDelegate.swift
@@ -20,7 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        let navigationController = UINavigationController(rootViewController: PhotoSelectorVC())
+        let navigationController = UINavigationController(rootViewController: MainVC())
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
     }

--- a/FindDict/FindDict/Global/Base/ModalBaseVC.swift
+++ b/FindDict/FindDict/Global/Base/ModalBaseVC.swift
@@ -69,7 +69,7 @@ class ModalBaseVC: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setLayout()
-        view.backgroundColor = .bgModal
+        view.backgroundColor = .bgBeige
     }
     
 

--- a/FindDict/FindDict/Global/Base/ModalBaseVC.swift
+++ b/FindDict/FindDict/Global/Base/ModalBaseVC.swift
@@ -69,10 +69,32 @@ class ModalBaseVC: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setLayout()
+        setButtonActions()
         view.backgroundColor = .bgBeige
     }
     
-
+    func setButtonActions(){
+        retryButton.press{
+//            self.view.window?.rootViewController?.dismiss(animated: false, completion: {
+//              let initiatingGameVC = PhotoSelectorVC()
+//                guard let presentingVC = self.presentingViewController as? UINavigationController else { return }
+//                self.view.window?.rootViewController?.dismiss(animated: false){
+//                           presentingVC.popToRootViewController(animated: true)}
+//            })
+        }
+        
+        dictionaryButton.press{
+//            let dictionaryVC = DictionaryVC()
+//            self.navigationController?.pushViewController(dictionaryVC, animated: true)
+        }
+        
+        mainViewButton.press{
+//            guard let pvc = self.presentingViewController else { return }
+//            self.dismiss(animated: true, completion: {
+//                pvc.navigationController?.pushViewController(MainVC(), animated: true)
+//            })
+        }
+    }
 }
 
 
@@ -86,6 +108,7 @@ extension ModalBaseVC {
             $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).inset(91)
             $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(116)
         }
+        
         resultTitleLabel.snp.makeConstraints{
             $0.top.equalTo(modalView).offset(53)
             $0.centerX.equalTo(modalView)
@@ -93,7 +116,7 @@ extension ModalBaseVC {
             $0.trailing.equalTo(modalView.snp.trailing).inset(183)
             $0.height.equalTo(102)
         }
-
+        
         buttonStackView.snp.makeConstraints{
             $0.top.equalTo(resultTitleLabel.snp.bottom).offset(29)
             $0.leading.equalTo(modalView.snp.leading).inset(570)
@@ -101,12 +124,10 @@ extension ModalBaseVC {
             $0.height.equalTo(231)
             $0.width.equalTo(312)
         }
+        
         resultImage.snp.makeConstraints{
             $0.top.equalTo(modalView.snp.top).inset(113)
             $0.trailing.equalTo(buttonStackView.snp.leading).offset(-21)
-
         }
-        
-
     }
 }

--- a/FindDict/FindDict/Global/Extensions/UIColor+.swift
+++ b/FindDict/FindDict/Global/Extensions/UIColor+.swift
@@ -24,6 +24,10 @@ extension UIColor {
         return UIColor(red: 248.0 / 255.0, green: 213.0 / 255.0, blue: 72.0 / 255.0, alpha: 1.0)
     }
     
+    @nonobjc class var buttonGray: UIColor {
+        return UIColor(white: 193.0 / 255.0, alpha: 1.0)
+      }
+    
     @nonobjc class var buttonApricot: UIColor {
         return UIColor(red: 249.0 / 255.0, green: 222.0 / 255.0, blue: 181.0 / 255.0, alpha: 1.0)
     }
@@ -40,21 +44,17 @@ extension UIColor {
         return UIColor(red: 1.0, green: 1.0, blue: 244.0 / 255.0, alpha: 1.0)
     }
     
-    @nonobjc class var dictionayGray: UIColor {
+    @nonobjc class var dictionaryGray: UIColor {
         return UIColor(white: 0.0, alpha: 0.15)
     }
     
     @nonobjc class var modalGray: UIColor {
         return UIColor(red: 243.0 / 255.0, green: 243.0 / 255.0, blue: 241.0 / 255.0, alpha: 1.0)
     }
-    
-    @nonobjc class var buttonGray: UIColor {
-        return UIColor(white: 0.0, alpha: 0.25)
-    }
-    
-    @nonobjc class var bgModal: UIColor {
-        return UIColor(red: 243.0 / 255.0, green: 243.0 / 255.0, blue: 241.0 / 255.0, alpha: 0.5)
-    }
+
+//    @nonobjc class var bgModal: UIColor {
+//        return UIColor(red: 243.0 / 255.0, green: 243.0 / 255.0, blue: 241.0 / 255.0, alpha: 0.5)
+//    }
     
     @nonobjc class var modalBrown: UIColor {
         return UIColor(red: 190.0 / 255.0, green: 122.0 / 255.0, blue: 16.0 / 255.0, alpha: 1.0)

--- a/FindDict/FindDict/Global/Extensions/UIView+.swift
+++ b/FindDict/FindDict/Global/Extensions/UIView+.swift
@@ -13,7 +13,6 @@ enum VerticalLocation {
     case left
     case right
     case bottomRight
-    case nadoBotttom
 }
 
 extension UIView {
@@ -60,9 +59,6 @@ extension UIView {
             addShadow(offset: CGSize(width: 10, height: 0), color: color, opacity: opacity, radius: radius)
         case .bottomRight:
             addShadow(offset: CGSize(width: 3, height: 3), color: color, opacity: opacity, radius: radius)
-        case .nadoBotttom:
-            addShadow(offset: CGSize(width: 0, height: 4), color: color, opacity: opacity, radius: radius)
         }
-        
     }
 }

--- a/FindDict/FindDict/Global/Extensions/UIView+.swift
+++ b/FindDict/FindDict/Global/Extensions/UIView+.swift
@@ -7,6 +7,15 @@
 
 import UIKit
 
+enum VerticalLocation {
+    case bottom
+    case top
+    case left
+    case right
+    case bottomRight
+    case nadoBotttom
+}
+
 extension UIView {
     func addSubViews(_ views: [UIView]) {
         views.forEach { self.addSubview($0) }
@@ -16,5 +25,44 @@ extension UIView {
     {
         let generator = UIImpactFeedbackGenerator(style: degree)
         generator.impactOccurred()
+    }
+    
+    /// UIView 의 모서리가 둥근 정도를 설정하는 메서드
+    func makeRounded(cornerRadius : CGFloat?) {
+        if let cornerRadius_ = cornerRadius {
+            self.layer.cornerRadius = cornerRadius_
+        }  else {
+            // cornerRadius 가 nil 일 경우의 default
+            self.layer.cornerRadius = self.layer.frame.height / 2
+        }
+        
+        self.layer.masksToBounds = true
+    }
+    
+    /// UIView의 그림자를 설정하는 메서드
+    func addShadow(offset: CGSize, color: UIColor = .gray, opacity: Float = 0.1, radius: CGFloat = 3.0) {
+        self.layer.masksToBounds = false
+        self.layer.shadowColor = color.cgColor
+        self.layer.shadowOffset = offset
+        self.layer.shadowOpacity = opacity
+        self.layer.shadowRadius = radius
+    }
+    
+    func addShadow(location: VerticalLocation, color: UIColor = .gray, opacity: Float = 0.2, radius: CGFloat = 5.0) {
+        switch location {
+        case .bottom:
+            addShadow(offset: CGSize(width: 0, height: 10), color: color, opacity: opacity, radius: radius)
+        case .top:
+            addShadow(offset: CGSize(width: 0, height: -4), color: color, opacity: opacity, radius: radius)
+        case .left:
+            addShadow(offset: CGSize(width: -10, height: 0), color: color, opacity: opacity, radius: radius)
+        case .right:
+            addShadow(offset: CGSize(width: 10, height: 0), color: color, opacity: opacity, radius: radius)
+        case .bottomRight:
+            addShadow(offset: CGSize(width: 3, height: 3), color: color, opacity: opacity, radius: radius)
+        case .nadoBotttom:
+            addShadow(offset: CGSize(width: 0, height: 4), color: color, opacity: opacity, radius: radius)
+        }
+        
     }
 }

--- a/FindDict/FindDict/Resources/WordDictionary.swift
+++ b/FindDict/FindDict/Resources/WordDictionary.swift
@@ -1,0 +1,16 @@
+//
+//  File.swift
+//  FindDict
+//
+//  Created by 김지민 on 2022/10/31.
+//
+
+import Foundation
+
+let wordDictionary: [String: String] = [
+    "bottle" : "물병",
+    "dining table": "식탁",
+    "cup":"컵",
+    "bowl":"둥근 그릇",
+    "knife":"칼"
+]

--- a/FindDict/FindDict/Sources/Scences/Dictionary/DictionaryCard.swift
+++ b/FindDict/FindDict/Sources/Scences/Dictionary/DictionaryCard.swift
@@ -50,7 +50,7 @@ class DictionaryCard: UIView {
     
     // MARK: Funtions
     private func setUI() {
-        self.backgroundColor = .dictionayGray
+        self.backgroundColor = .dictionaryGray
         self.layer.cornerRadius = 10.0
     }
 }

--- a/FindDict/FindDict/Sources/Scences/Game/GameVC.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/GameVC.swift
@@ -47,7 +47,16 @@ class GameVC:ViewController {
     
     // TODO: - 버튼 위치 잘 잡고 나면 삭제할 프로퍼티
     private var colors: [String: UIColor] = [:]
-    
+    private var theNumberOfTargetsGuessedRight = 0 {
+        didSet{
+            if theNumberOfTargetsGuessedRight == wordTargets.count {
+                let gameResultSuccessVC = GameResultSuccessVC()
+                gameResultSuccessVC.modalTransitionStyle = .crossDissolve
+                gameResultSuccessVC.modalPresentationStyle = .overFullScreen
+                self.present(gameResultSuccessVC, animated: true)
+            }
+        }
+    }
     
     // MARK: - UI Properties
     private let logoImage = UIImageView().then{
@@ -79,12 +88,13 @@ class GameVC:ViewController {
     private lazy var buttons: [UIButton] = [] {
         didSet{
             for button in buttons {
-                button.press{
+                button.press{ [self] in 
                     button.setImage(UIImage(named: "icon"), for: .normal)
                     button.imageView?.contentMode = .scaleAspectFit
                     button.isUserInteractionEnabled = false
                     self.disableButtons(label:button.titleLabel?.text ?? "레이블 오류")
                     self.handleGuessedRightView(label:button.titleLabel?.text ?? "레이블 오류")
+                    self.theNumberOfTargetsGuessedRight += 1
                 }
                 buttonLayer.addSubview(button)
             }
@@ -120,6 +130,7 @@ class GameVC:ViewController {
             
         }
         wordTargets = createdTargets
+//        numberOfTargetWords = wordTargets.count
     }
     
     /// 인식된 객체마다 이에 맞는 버튼을 생성합니다.

--- a/FindDict/FindDict/Sources/Scences/Game/GameVC.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/GameVC.swift
@@ -12,7 +12,7 @@ import SnapKit
 import Then
 
 
-class ObjectDetectionVC:ViewController {
+class GameVC:ViewController {
     
     private let logoImage = UIImageView().then{
         $0.contentMode = .scaleAspectFit
@@ -21,9 +21,7 @@ class ObjectDetectionVC:ViewController {
     
     private let targetListContainerView = UIStackView().then{
         $0.axis = .horizontal
-//        $0.alignment = .fill
         $0.spacing = 20
-//        $0.distribution = .fillProportionally
     }
     
     var pixelBuffer:CVPixelBuffer? = nil {
@@ -85,6 +83,9 @@ class ObjectDetectionVC:ViewController {
             }
         }
     }
+    // TODO: 모든 객체 리스트 비활성화됐을 경우 게임 종료
+    // TODO: 버튼 부분 아닌 곳 클릭했을 경우 x표시 나타나기
+    
     
     // MARK: - Vision Properties
     var request: VNCoreMLRequest?
@@ -156,7 +157,6 @@ class ObjectDetectionVC:ViewController {
     public var predictedObjects: [VNRecognizedObjectObservation] = [] {
         didSet {
             putButtons(with: predictedObjects)
-//            predictedObjectsSet = Set(predictedObjects)
             var predectedObjectLabels = Set<String>()
             for predictedObject in predictedObjects {
                 predectedObjectLabels.insert(predictedObject.label ?? "레이블오류")
@@ -175,13 +175,11 @@ class ObjectDetectionVC:ViewController {
         var createdButtons:[UIButton]=[]
         for prediction in predictions {
             createdButtons.append(createButton(prediction: prediction))
-//            predictedObjectsSet.insert(prediction.label ?? "no label")
         }
         buttons = createdButtons
     }
     
     func createTargetListComponents(with predictions: Set<String>){
-//        print(predictions)
         var createdTargets:[TargetListComponentView]=[]
         for prediction in predictions {
             let component = TargetListComponentView()
@@ -226,13 +224,10 @@ class ObjectDetectionVC:ViewController {
 //        button.titleLabel?.alpha = 0
         return button
     }
-//    @objc func buttonClicked(_ sender:UIButton) -> Void {
-//        print(sender.titleLabel?.text)
-//    }
 }
 
 // MARK: - UI
-extension ObjectDetectionVC {
+extension GameVC {
     func setLayout() {
         view.addSubViews([logoImage, targetListContainerView, image])
         logoImage.snp.makeConstraints{
@@ -244,9 +239,6 @@ extension ObjectDetectionVC {
         targetListContainerView.snp.makeConstraints{
             $0.top.equalTo(logoImage.snp.bottom).offset(40)
             $0.centerX.equalTo(view.safeAreaLayoutGuide)
-//            $0.leading.lessThanOrEqualTo(view.safeAreaLayoutGuide.snp.leading).inset(50)
-//            $0.trailing.lessThanOrEqualTo(view.safeAreaLayoutGuide.snp.trailing).inset(50)
-//            $0.height.equalTo(100)
         }
         
         image.snp.makeConstraints{

--- a/FindDict/FindDict/Sources/Scences/Game/ObjectDetection.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/ObjectDetection.swift
@@ -54,9 +54,7 @@ class ObjectDetectionVC:ViewController {
                     button.imageView?.contentMode = .scaleAspectFit
                     button.isUserInteractionEnabled = false
                     self.disableButtons(label:button.titleLabel?.text ?? "레이블 오류")
-                    // TODO: 객체 리스트에서 같은 label인 버튼 비활성화
-                    
-                    // TODO: 객체 리스트에서 같은 label인 레이블 영어 단어 보여주기
+                    self.handleGuessedRightView(label:button.titleLabel?.text ?? "레이블 오류")
                     
                 }
                 buttonLayer.addSubview(button)
@@ -76,6 +74,14 @@ class ObjectDetectionVC:ViewController {
         for button in buttons{
             if button.titleLabel?.text == label{
                 button.isUserInteractionEnabled = false
+            }
+        }
+    }
+    
+    func handleGuessedRightView(label:String){
+        for wordTarget in wordTargets{
+            if wordTarget.getTargetLabel() == label {
+                wordTarget.handleGussedRightView()
             }
         }
     }

--- a/FindDict/FindDict/Sources/Scences/Game/ObjectDetection.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/ObjectDetection.swift
@@ -15,10 +15,15 @@ import Then
 class ObjectDetectionVC:ViewController {
     
     private let logoImage = UIImageView().then{
+        $0.contentMode = .scaleAspectFit
         $0.image = UIImage(named: "logoImage")
     }
     
-    private let targetListContainerView = UIStackView()
+    private let targetListContainerView = UIStackView().then{
+        $0.axis = .horizontal
+//        $0.spacing = 10
+//        $0.distribution = .fillProportionally
+    }
     
     var pixelBuffer:CVPixelBuffer? = nil {
         didSet{
@@ -28,6 +33,7 @@ class ObjectDetectionVC:ViewController {
     }
     var image = UIImageView().then{
         $0.isUserInteractionEnabled = true
+        $0.contentMode = .scaleAspectFit
     }
     var buttonLayer = UIView()
     
@@ -127,12 +133,15 @@ class ObjectDetectionVC:ViewController {
         var createdButtons:[UIButton]=[]
         for prediction in predictions {
             createdButtons.append(createButton(prediction: prediction))
+            createTargetListComponents(prediction: prediction)
         }
         buttons = createdButtons
     }
     
-    func createTargetListComponents(){
+    func createTargetListComponents(prediction: VNRecognizedObjectObservation){
         let component = TargetListComponentView()
+        component.setData(korean: prediction.label ?? "개미", english: prediction.label ?? "ant")
+        targetListContainerView.addArrangedSubview(component)
         
     }
     
@@ -180,11 +189,15 @@ extension ObjectDetectionVC {
         logoImage.snp.makeConstraints{
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(17)
             $0.centerX.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(80)
         }
         
         targetListContainerView.snp.makeConstraints{
             $0.top.equalTo(logoImage.snp.bottom).offset(40)
             $0.centerX.equalTo(view.safeAreaLayoutGuide)
+//            $0.leading.lessThanOrEqualTo(view.safeAreaLayoutGuide.snp.leading).inset(50)
+//            $0.trailing.lessThanOrEqualTo(view.safeAreaLayoutGuide.snp.trailing).inset(50)
+            $0.height.equalTo(100)
         }
         
         image.snp.makeConstraints{

--- a/FindDict/FindDict/Sources/Scences/Game/ObjectDetection.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/ObjectDetection.swift
@@ -156,7 +156,7 @@ class ObjectDetectionVC:ViewController {
 //        print(predictions)
         for prediction in predictions {
             let component = TargetListComponentView()
-            component.setData(korean: prediction, english: prediction)
+            component.setData(korean: wordDictionary[prediction] ?? "사전 매칭 오류", english: prediction)
             targetListContainerView.addArrangedSubview(component)
         }
     }

--- a/FindDict/FindDict/Sources/Scences/Game/ObjectDetection.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/ObjectDetection.swift
@@ -53,8 +53,22 @@ class ObjectDetectionVC:ViewController {
                     button.setImage(UIImage(named: "icon"), for: .normal)
                     button.imageView?.contentMode = .scaleAspectFit
                     button.isUserInteractionEnabled = false
+                    // TODO: 같은 label인 버튼들 비활성화
+                    self.disableButtons(label:button.titleLabel?.text ?? "레이블 오류")
+                    // TODO: 객체 리스트에서 같은 label인 버튼 비활성화
+                    
+                    // TODO: 객체 리스트에서 같은 label인 레이블 영어 단어 보여주기
+                    
                 }
                 buttonLayer.addSubview(button)
+            }
+        }
+    }
+    
+    func disableButtons(label:String){
+        for button in buttons{
+            if button.titleLabel?.text == label{
+                button.isUserInteractionEnabled = false
             }
         }
     }
@@ -190,12 +204,14 @@ class ObjectDetectionVC:ViewController {
         button.layer.borderWidth = 4
         button.backgroundColor = UIColor.clear
         button.setTitle(buttonTitle, for: .normal)
+//        button.setTitleColor(.black, for: .normal)
+//        button.setTitleColor(.systemRed, for: .disabled)
 //        button.titleLabel?.alpha = 0
         return button
     }
-    @objc func buttonClicked(_ sender:UIButton) -> Void {
-        print(sender.titleLabel?.text)
-    }
+//    @objc func buttonClicked(_ sender:UIButton) -> Void {
+//        print(sender.titleLabel?.text)
+//    }
 }
 
 // MARK: - UI

--- a/FindDict/FindDict/Sources/Scences/Game/ObjectDetection.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/ObjectDetection.swift
@@ -51,6 +51,7 @@ class ObjectDetectionVC:ViewController {
             for button in buttons {
                 button.press{
                     button.setImage(UIImage(named: "icon"), for: .normal)
+                    button.imageView?.contentMode = .scaleAspectFit
                     button.isUserInteractionEnabled = false
                 }
                 buttonLayer.addSubview(button)

--- a/FindDict/FindDict/Sources/Scences/Game/ObjectDetection.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/ObjectDetection.swift
@@ -53,7 +53,6 @@ class ObjectDetectionVC:ViewController {
                     button.setImage(UIImage(named: "icon"), for: .normal)
                     button.imageView?.contentMode = .scaleAspectFit
                     button.isUserInteractionEnabled = false
-                    // TODO: 같은 label인 버튼들 비활성화
                     self.disableButtons(label:button.titleLabel?.text ?? "레이블 오류")
                     // TODO: 객체 리스트에서 같은 label인 버튼 비활성화
                     
@@ -61,6 +60,14 @@ class ObjectDetectionVC:ViewController {
                     
                 }
                 buttonLayer.addSubview(button)
+            }
+        }
+    }
+    
+    lazy var wordTargets: [TargetListComponentView] = []{
+        didSet{
+            for wordTarget in wordTargets{
+                targetListContainerView.addArrangedSubview(wordTarget)
             }
         }
     }
@@ -168,11 +175,14 @@ class ObjectDetectionVC:ViewController {
     
     func createTargetListComponents(with predictions: Set<String>){
 //        print(predictions)
+        var createdTargets:[TargetListComponentView]=[]
         for prediction in predictions {
             let component = TargetListComponentView()
             component.setData(korean: wordDictionary[prediction] ?? "사전 매칭 오류", english: prediction)
-            targetListContainerView.addArrangedSubview(component)
+            createdTargets.append(component)
+            
         }
+        wordTargets = createdTargets
     }
     
     func createButton(prediction: VNRecognizedObjectObservation)-> UIButton {

--- a/FindDict/FindDict/Sources/Scences/Game/ObjectDetection.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/ObjectDetection.swift
@@ -14,6 +14,12 @@ import Then
 
 class ObjectDetectionVC:ViewController {
     
+    private let logoImage = UIImageView().then{
+        $0.image = UIImage(named: "logoImage")
+    }
+    
+    private let targetListContainerView = UIStackView()
+    
     var pixelBuffer:CVPixelBuffer? = nil {
         didSet{
             setUpModel()
@@ -23,8 +29,9 @@ class ObjectDetectionVC:ViewController {
     var image = UIImageView().then{
         $0.isUserInteractionEnabled = true
     }
+    var buttonLayer = UIView()
     
-    let objectDectectionModel = yolov7()
+    let objectDectectionModel = yolov5m()
     //    yolov7()
     //yolov5m()
     var predictions: [VNRecognizedObjectObservation] = []
@@ -36,10 +43,10 @@ class ObjectDetectionVC:ViewController {
         didSet{
             for button in buttons {
                 button.press{
-                    // TODO: 이미지 바꾸기
                     button.setImage(UIImage(named: "icon"), for: .normal)
+                    button.isUserInteractionEnabled = false
                 }
-                image.addSubview(button)
+                buttonLayer.addSubview(button)
             }
         }
     }
@@ -98,9 +105,10 @@ class ObjectDetectionVC:ViewController {
     func visionRequestDidComplete(request: VNRequest, error: Error?) {
         if let predictions = request.results as? [VNRecognizedObjectObservation] {
             DispatchQueue.main.async {
-                //                self.image.layer.addSublayer(boxesView)
-                //                self.boxesView.bounds = self.image.bounds
-                //                self.boxesView.bounds = self.image.frame
+                self.image.addSubview(self.buttonLayer)
+//                                self.image.layer.addSublayer(buttonLayer)
+//                                self.buttonLayer.bounds = self.image.bounds
+                                self.buttonLayer.frame = self.image.bounds
                 self.predictedObjects = predictions
                 self.isInferencing = false
             }
@@ -123,6 +131,11 @@ class ObjectDetectionVC:ViewController {
         buttons = createdButtons
     }
     
+    func createTargetListComponents(){
+        let component = TargetListComponentView()
+        
+    }
+    
     func createButton(prediction: VNRecognizedObjectObservation)-> UIButton {
         let buttonTitle: String? = prediction.label
         let color: UIColor = labelColor(with: buttonTitle ?? "N/A")
@@ -137,7 +150,7 @@ class ObjectDetectionVC:ViewController {
         //        print(buttonRect)
         //        print(labelString,bgRect)
 //                let buttonRect = CGRect(x: prediction.boundingBox.origin.x, y: prediction.boundingBox.origin.y, width: prediction.boundingBox.width, height: prediction.boundingBox.height)
-        let scale = CGAffineTransform.identity.scaledBy(x: image.bounds.width, y: image.bounds.height)
+        let scale = CGAffineTransform.identity.scaledBy(x: buttonLayer.bounds.width, y: buttonLayer.bounds.height)
         print("scale",scale)
         let transform = CGAffineTransform(scaleX: 1, y: -1).translatedBy(x: 0, y: -1)
         let bgRect = prediction.boundingBox.applying(transform).applying(scale)
@@ -159,13 +172,24 @@ class ObjectDetectionVC:ViewController {
         print(sender.titleLabel?.text)
     }
 }
+
 // MARK: - UI
 extension ObjectDetectionVC {
     func setLayout() {
-        view.addSubViews([image])
-        image.snp.makeConstraints{
+        view.addSubViews([logoImage, targetListContainerView, image])
+        logoImage.snp.makeConstraints{
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(17)
-            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+            $0.centerX.equalTo(view.safeAreaLayoutGuide)
+        }
+        
+        targetListContainerView.snp.makeConstraints{
+            $0.top.equalTo(logoImage.snp.bottom).offset(40)
+            $0.centerX.equalTo(view.safeAreaLayoutGuide)
+        }
+        
+        image.snp.makeConstraints{
+            $0.top.equalTo(targetListContainerView.snp.bottom).offset(60)
+            $0.centerX.equalTo(view.safeAreaLayoutGuide)
             $0.bottom.lessThanOrEqualTo(view.safeAreaLayoutGuide.snp.bottom).inset(50)
         }
     }

--- a/FindDict/FindDict/Sources/Scences/Game/ObjectDetection.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/ObjectDetection.swift
@@ -96,6 +96,7 @@ class ObjectDetectionVC:ViewController {
     // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        view.backgroundColor = .bgBeige
         setLayout()
     }
     static private var colors: [String: UIColor] = [:]
@@ -245,11 +246,11 @@ extension ObjectDetectionVC {
             $0.centerX.equalTo(view.safeAreaLayoutGuide)
 //            $0.leading.lessThanOrEqualTo(view.safeAreaLayoutGuide.snp.leading).inset(50)
 //            $0.trailing.lessThanOrEqualTo(view.safeAreaLayoutGuide.snp.trailing).inset(50)
-            $0.height.equalTo(100)
+//            $0.height.equalTo(100)
         }
         
         image.snp.makeConstraints{
-            $0.top.equalTo(targetListContainerView.snp.bottom).offset(60)
+            $0.top.equalTo(targetListContainerView.snp.bottom).offset(30)
             $0.centerX.equalTo(view.safeAreaLayoutGuide)
             $0.bottom.lessThanOrEqualTo(view.safeAreaLayoutGuide.snp.bottom).inset(50)
         }

--- a/FindDict/FindDict/Sources/Scences/Game/ObjectDetection.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/ObjectDetection.swift
@@ -21,7 +21,8 @@ class ObjectDetectionVC:ViewController {
     
     private let targetListContainerView = UIStackView().then{
         $0.axis = .horizontal
-//        $0.spacing = 10
+//        $0.alignment = .fill
+        $0.spacing = 20
 //        $0.distribution = .fillProportionally
     }
     

--- a/FindDict/FindDict/Sources/Scences/Game/ObjectDetection.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/ObjectDetection.swift
@@ -128,6 +128,18 @@ class ObjectDetectionVC:ViewController {
     public var predictedObjects: [VNRecognizedObjectObservation] = [] {
         didSet {
             putButtons(with: predictedObjects)
+//            predictedObjectsSet = Set(predictedObjects)
+            var predectedObjectLabels = Set<String>()
+            for predictedObject in predictedObjects {
+                predectedObjectLabels.insert(predictedObject.label ?? "레이블오류")
+            }
+            predictedObjectLablesSet = predectedObjectLabels
+        }
+    }
+    
+    public var predictedObjectLablesSet = Set<String>() {
+        didSet {
+            createTargetListComponents(with: predictedObjectLablesSet)
         }
     }
     
@@ -135,16 +147,18 @@ class ObjectDetectionVC:ViewController {
         var createdButtons:[UIButton]=[]
         for prediction in predictions {
             createdButtons.append(createButton(prediction: prediction))
-            createTargetListComponents(prediction: prediction)
+//            predictedObjectsSet.insert(prediction.label ?? "no label")
         }
         buttons = createdButtons
     }
     
-    func createTargetListComponents(prediction: VNRecognizedObjectObservation){
-        let component = TargetListComponentView()
-        component.setData(korean: prediction.label ?? "개미", english: prediction.label ?? "ant")
-        targetListContainerView.addArrangedSubview(component)
-        
+    func createTargetListComponents(with predictions: Set<String>){
+//        print(predictions)
+        for prediction in predictions {
+            let component = TargetListComponentView()
+            component.setData(korean: prediction, english: prediction)
+            targetListContainerView.addArrangedSubview(component)
+        }
     }
     
     func createButton(prediction: VNRecognizedObjectObservation)-> UIButton {

--- a/FindDict/FindDict/Sources/Scences/Game/PhotoSelectorVC.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/PhotoSelectorVC.swift
@@ -43,6 +43,7 @@ class PhotoSelectorVC: UIViewController {
         super.viewDidLoad()
         setLayout()
         setButtonActions()
+        view.backgroundColor = .bgBeige
     }
     
     // MARK: - Functions

--- a/FindDict/FindDict/Sources/Scences/Game/PhotoSelectorVC.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/PhotoSelectorVC.swift
@@ -12,7 +12,6 @@ import Then
 class PhotoSelectorVC: UIViewController {
     
     // MARK: - Properties
-    private let boxesView = DrawingBoundingBoxView()
     private let takingPictureButton = PhotoSelectorButton().then{
         $0.setTitle("사진 찍기", for: .normal)
         $0.backgroundColor = .buttonOrange
@@ -29,26 +28,15 @@ class PhotoSelectorVC: UIViewController {
     }
     
     private var selectedImage = UIImageView()
-//    {
-//        didSet{
-//            print("imagesdsdsada")
-//            let objectDetectionTestVC = ObjectDetectionVC()
-//            objectDetectionTestVC.pixelBuffer = selectedImage.image?.pixelBufferFromImage()
-//            self.navigationController?.pushViewController(objectDetectionTestVC, animated: true)
-//        }
-//    }
-//
+    
     private var pixelBuffer:CVPixelBuffer? = nil  {
         didSet{
-            let objectDetectionTestVC = ObjectDetectionVC()
+            let objectDetectionTestVC = GameVC()
             objectDetectionTestVC.image.image = selectedImage.image
-                        objectDetectionTestVC.pixelBuffer = selectedImage.image?.pixelBufferFromImage()
-                        self.navigationController?.pushViewController(objectDetectionTestVC, animated: true)
-            
+            objectDetectionTestVC.pixelBuffer = selectedImage.image?.pixelBufferFromImage()
+            self.navigationController?.pushViewController(objectDetectionTestVC, animated: true)
         }
     }
-    
-//    let objectDetection = ObjectDetection()
     
     // MARK: - View Life Cycle
     override func viewDidLoad() {
@@ -56,7 +44,7 @@ class PhotoSelectorVC: UIViewController {
         setLayout()
         setButtonActions()
     }
-
+    
     // MARK: - Functions
     func setButtonActions(){
         takingPictureButton.press{
@@ -75,16 +63,12 @@ class PhotoSelectorVC: UIViewController {
             self.present(imagePickerController, animated: true, completion: nil)
         }
     }
-
 }
 
 // MARK: - UI
 extension PhotoSelectorVC {
     private func setLayout() {
-        view.addSubViews([takingPictureButton, selectingPictureButton,fetchingPictureButton,
-//                          boxesView
-                          selectedImage
-                         ])
+        view.addSubViews([takingPictureButton, selectingPictureButton,fetchingPictureButton])
         
         takingPictureButton.snp.makeConstraints{
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(67)
@@ -92,7 +76,7 @@ extension PhotoSelectorVC {
             $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).offset(-60)
             $0.height.equalTo(100)
         }
-
+        
         selectingPictureButton.snp.makeConstraints{
             $0.top.equalTo(takingPictureButton.snp.bottom).offset(17)
             $0.leading.equalTo(view.safeAreaLayoutGuide.snp.leading).offset(60)
@@ -106,22 +90,6 @@ extension PhotoSelectorVC {
             $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).offset(-60)
             $0.height.equalTo(100)
         }
-        
-        selectedImage.snp.makeConstraints{
-            $0.top.equalTo(fetchingPictureButton.snp.bottom).offset(17)
-            $0.leading.equalTo(view.safeAreaLayoutGuide.snp.leading).offset(60)
-            $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).offset(-60)
-            $0.bottom.lessThanOrEqualTo(view.safeAreaLayoutGuide.snp.bottom).inset(50)
-            $0.height.equalTo(250)
-        }
-        
-//        boxesView.snp.makeConstraints{
-//            $0.top.equalTo(fetchingPictureButton.snp.bottom).offset(17)
-//            $0.leading.equalTo(view.safeAreaLayoutGuide.snp.leading).offset(60)
-//            $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).offset(-60)
-//            $0.bottom.lessThanOrEqualTo(view.safeAreaLayoutGuide.snp.bottom).inset(50)
-//            $0.height.equalTo(250)
-//        }
     }
 }
 
@@ -129,25 +97,16 @@ extension PhotoSelectorVC {
 extension PhotoSelectorVC:UIImagePickerControllerDelegate, UINavigationControllerDelegate{
     
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
-      
-                if let image = info[.editedImage] as? UIImage
+        
+        if let image = info[.editedImage] as? UIImage
         {
-                   
-                    selectedImage.image = image
-                    pixelBuffer = selectedImage.image?.pixelBufferFromImage()
-//                    let imagePixelBuffer = image.pixelBufferFromImage()
-//                    objectDetection.setUpModel()
-//                    objectDetection.handleImage(pixelBuffer: imagePixelBuffer)
-                }
-        
-             dismiss(animated: true, completion: nil)
-//        let objectDetectionTestVC = ObjectDetectionVC()
-//        objectDetectionTestVC.pixelBuffer = image?.pixelBufferFromImage()
-//        self.navigationController?.pushViewController(objectDetectionTestVC, animated: true)
-        
+            selectedImage.image = image
+            pixelBuffer = selectedImage.image?.pixelBufferFromImage()
         }
+        dismiss(animated: true, completion: nil)
+    }
     
     func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
-          dismiss(animated: true, completion: nil)
-      }
+        dismiss(animated: true, completion: nil)
+    }
 }

--- a/FindDict/FindDict/Sources/Scences/Game/TargetListComponentView.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/TargetListComponentView.swift
@@ -63,6 +63,16 @@ class TargetListComponentView: UIView {
             print("힌트 보기")
         }
     }
+    
+    func getTargetLabel()->String{
+        return englishLabelText
+    }
+    
+    func handleGussedRightView(){
+        koreanButton.isUserInteractionEnabled = false
+        englishLabel.text = englishLabelText
+        
+    }
 
 }
 

--- a/FindDict/FindDict/Sources/Scences/Game/TargetListComponentView.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/TargetListComponentView.swift
@@ -1,0 +1,70 @@
+//
+//  TargetListComponentView.swift
+//  FindDict
+//
+//  Created by 김지민 on 2022/10/27.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+class TargetListComponentView: UIView {
+    
+    private var guessedRight = true
+
+    private let koreanButton = UIButton().then{
+        $0.makeRounded(cornerRadius: nil)
+    }
+    
+    private let englishLabel = UILabel().then{
+        $0.addShadow(location: .bottom)
+        $0.addShadow(location: .left)
+        $0.addShadow(location: .right)
+        $0.backgroundColor = .white
+        $0.textColor = .black
+        $0.text = "-"
+    }
+    
+    private var englishLabelText :String = ""
+    
+    // MARK: - Initialization
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        setLayout()
+    }
+    
+    required init(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)!
+    }
+    
+    // MARK: - Functions
+    func setData(korean:String, english:String){
+        koreanButton.setTitle(korean, for: .normal)
+        englishLabelText = english
+    }
+    
+    func setButtonActions(){
+        koreanButton.press{
+            print("힌트 보기")
+        }
+    }
+
+}
+
+extension TargetListComponentView {
+    func setLayout() {
+        self.addSubViews([koreanButton,englishLabel])
+        
+        koreanButton.snp.makeConstraints {
+            $0.top.equalTo(self.safeAreaLayoutGuide).offset(11)
+            $0.centerX.equalTo(self.safeAreaLayoutGuide)
+        }
+        
+        englishLabel.snp.makeConstraints{
+            $0.top.equalTo(koreanButton.snp.bottom).offset(15)
+            $0.centerX.equalTo(self.safeAreaLayoutGuide)
+        }
+        
+    }
+}

--- a/FindDict/FindDict/Sources/Scences/Game/TargetListComponentView.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/TargetListComponentView.swift
@@ -14,13 +14,26 @@ class TargetListComponentView: UIView {
     private var guessedRight = true
 
     private let koreanButton = UIButton().then{
-        $0.makeRounded(cornerRadius: nil)
+        if #available(iOS 15.0, *) {
+            $0.configuration = .plain()
+            $0.configuration?.buttonSize = .large
+        } else {
+            // Fallback on earlier versions
+        }
+        
+        $0.makeRounded(cornerRadius: 20)
+        
+        $0.backgroundColor = .buttonYellow
+        $0.setTitleColor(.black, for: .normal)
     }
     
     private let englishLabel = UILabel().then{
         $0.addShadow(location: .bottom)
         $0.addShadow(location: .left)
         $0.addShadow(location: .right)
+        $0.makeRounded(cornerRadius: 15)
+//        $0.sizeToFit()
+        $0.textAlignment = .center
         $0.backgroundColor = .white
         $0.textColor = .black
         $0.text = "-"
@@ -58,12 +71,13 @@ extension TargetListComponentView {
         
         koreanButton.snp.makeConstraints {
             $0.top.equalTo(self.safeAreaLayoutGuide).offset(11)
-            $0.centerX.equalTo(self.safeAreaLayoutGuide)
+            $0.leading.trailing.equalTo(self.safeAreaLayoutGuide)
         }
         
         englishLabel.snp.makeConstraints{
             $0.top.equalTo(koreanButton.snp.bottom).offset(15)
-            $0.centerX.equalTo(self.safeAreaLayoutGuide)
+            $0.leading.trailing.equalTo(self.safeAreaLayoutGuide)
+            $0.height.equalTo(30)
         }
         
     }

--- a/FindDict/FindDict/Sources/Scences/Game/TargetListComponentView.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/TargetListComponentView.swift
@@ -27,16 +27,44 @@ class TargetListComponentView: UIView {
         $0.setTitleColor(.black, for: .normal)
     }
     
-    private let englishLabel = UILabel().then{
-        $0.addShadow(location: .bottom)
-        $0.addShadow(location: .left)
-        $0.addShadow(location: .right)
+    private let englishLabelBoundaryView = UIView().then {
+//        $0.addShadow(location: .bottom)
+//                $0.addShadow(location: .left)
+//                $0.addShadow(location: .right)
+//        $0.addShadow(offset: CGSize(width: 0, height: -2),opacity: 0.2,radius: 2.0)
+        $0.layer.shadowRadius = 4
+                $0.layer.shadowOffset = CGSize(width: 0, height: 4)
+                $0.layer.shadowColor = UIColor.black.cgColor
+                $0.layer.shadowOpacity = 0.25
+        $0.backgroundColor = .white
         $0.makeRounded(cornerRadius: 15)
+    }
+    
+    private let englishLabel = UILabel().then{
+//        $0.addShadow(location: .bottom)
+//        $0.addShadow(location: .left)
+//        $0.addShadow(location: .right)
+//        $0.addShadow(offset: CGSize(width: 0, height: -2),opacity: 0.2,radius: 2.0)
+//        $0.shadowColor
+//        $0.shadowColor = .black
+//        $0.shadowOffset = CGSize(width: 0, height: 4)
+        
+//        $0.layer.shadowRadius = 4
+//        $0.layer.shadowOffset = CGSize(width: 0, height: 4)
+//        $0.layer.shadowColor = UIColor.black.cgColor
+//        $0.layer.shadowOpacity = 0.25
+//        $0.makeRounded(cornerRadius: 15)
 //        $0.sizeToFit()
         $0.textAlignment = .center
-        $0.backgroundColor = .white
+//        $0.backgroundColor = .white
         $0.textColor = .black
         $0.text = "-"
+//
+//        $0.addShadow(location: .bottom)
+//                $0.addShadow(location: .left)
+//                $0.addShadow(location: .right)
+//        $0.backgroundColor = .white
+//        $0.makeRounded(cornerRadius: 15)
     }
     
     private var englishLabelText :String = ""
@@ -71,25 +99,44 @@ class TargetListComponentView: UIView {
     func handleGussedRightView(){
         koreanButton.isUserInteractionEnabled = false
         englishLabel.text = englishLabelText
-        
+        koreanButton.backgroundColor = .buttonGray
     }
 
 }
 
 extension TargetListComponentView {
     func setLayout() {
-        self.addSubViews([koreanButton,englishLabel])
+        self.addSubViews([koreanButton
+                          ,englishLabelBoundaryView
+                          ,englishLabel])
         
         koreanButton.snp.makeConstraints {
             $0.top.equalTo(self.safeAreaLayoutGuide).offset(11)
+            $0.height.equalTo(40)
             $0.leading.trailing.equalTo(self.safeAreaLayoutGuide)
         }
         
-        englishLabel.snp.makeConstraints{
+        englishLabelBoundaryView.snp.makeConstraints{
             $0.top.equalTo(koreanButton.snp.bottom).offset(15)
             $0.leading.trailing.equalTo(self.safeAreaLayoutGuide)
-            $0.height.equalTo(30)
+            $0.height.equalTo(40)
+            $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(10)
         }
+        englishLabel.snp.makeConstraints{
+//            $0.top.equalTo(koreanButton.snp.bottom).offset(15)
+            $0.leading.equalTo(englishLabelBoundaryView).offset(10)
+            $0.trailing.equalTo(englishLabelBoundaryView).inset(10)
+            $0.center.equalTo(englishLabelBoundaryView)
+//            $0.height.equalTo(40)
+//            $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(10)
+        }
+        
+//        englishLabel.snp.makeConstraints{
+//            $0.top.equalTo(koreanButton.snp.bottom).offset(15)
+//            $0.leading.trailing.equalTo(self.safeAreaLayoutGuide)
+//            $0.height.equalTo(40)
+//            $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(10)
+//        }
         
     }
 }

--- a/FindDict/FindDict/Sources/Scences/Game/TargetListComponentView.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/TargetListComponentView.swift
@@ -45,6 +45,7 @@ class TargetListComponentView: UIView {
     override init(frame: CGRect) {
         super.init(frame: .zero)
         setLayout()
+        setButtonActions()
     }
     
     required init(coder aDecoder: NSCoder) {

--- a/FindDict/FindDict/Sources/Scences/Game/TargetListComponentView.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/TargetListComponentView.swift
@@ -122,21 +122,11 @@ extension TargetListComponentView {
             $0.height.equalTo(40)
             $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(10)
         }
+        
         englishLabel.snp.makeConstraints{
-//            $0.top.equalTo(koreanButton.snp.bottom).offset(15)
             $0.leading.equalTo(englishLabelBoundaryView).offset(10)
             $0.trailing.equalTo(englishLabelBoundaryView).inset(10)
             $0.center.equalTo(englishLabelBoundaryView)
-//            $0.height.equalTo(40)
-//            $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(10)
         }
-        
-//        englishLabel.snp.makeConstraints{
-//            $0.top.equalTo(koreanButton.snp.bottom).offset(15)
-//            $0.leading.trailing.equalTo(self.safeAreaLayoutGuide)
-//            $0.height.equalTo(40)
-//            $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(10)
-//        }
-        
     }
 }

--- a/FindDict/FindDict/Sources/Scences/Main/MainVC.swift
+++ b/FindDict/FindDict/Sources/Scences/Main/MainVC.swift
@@ -9,7 +9,7 @@ import UIKit
 import SnapKit
 import Then
 
-class mainVC: UIViewController {
+class MainVC: UIViewController {
     
     // MARK: - Properties
     private let logoImage = UIImageView().then{
@@ -39,13 +39,29 @@ class mainVC: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setLayout()
+        setButtonActions()
         view.backgroundColor = .bgYellow
     }
 
+    func setButtonActions(){
+        gameStartButton.press{
+            let initiatingGameVC = PhotoSelectorVC()
+            self.navigationController?.pushViewController(initiatingGameVC, animated: true)
+        }
+        
+        gameRuleButton.press{
+            print("게임 방법 뷰로 이동")
+        }
+        
+        dictionaryButton.press{
+            let dictionaryVC = DictionaryVC()
+            self.navigationController?.pushViewController(dictionaryVC, animated: true)
+        }
+    }
 }
 
 // MARK: - UI
-extension mainVC {
+extension MainVC {
     private func setLayout(){
         view.addSubViews([logoImage,gameStartButton, buttonStackView])
         


### PR DESCRIPTION
## 작업한 내용
- 찾아야 하는 타겟 물체 리스트 뷰 제작
  - 한국어 클릭 시 힌트 모달 나오게 할 준비(버튼 이벤트 연결, print 문 출력까지만 해두었습니다)
- 인식된 물체에 맞게 리스트 뷰 생성하여 스택뷰에 추가
- 물체들 위에 올려진 여러 버튼 중 하나 클릭했을 경우 (정답처리)
  - 동일한 label의 버튼들은 비활성화되도록
  -  리스트 뷰에서 해당 label 뷰 색상 변화
  - 리스트 뷰에서 해당 label 뷰의 영어 단어 나타나도록
  - 정답 처리된 label 개수 누적하고 있던 중 전체 label 개수와 같아질 경우 성공 모달 보이며 게임 종료
## PR Point
- 객체 인식 결과를 바탕으로 버튼과 리스트 뷰를 세팅하되, 버튼은 중복 label 허용을 위해 Array을, 리스트 뷰는 중복 제거를 위해 Set에 저장을 하였습니다.
- 영어 한국어 매칭 관리를 위해 wordDictionary라는 Dictionary가 담긴 파일을 만들었습니다. 
- 리스트 뷰에서 영어 단어 레이블에 그림자를 주고 싶은데 잘 되지 않네요...ㅜ 레이블 단독 사용 방법에서, UIView위에 레이블을 올리는 걸로 방식을 바꿨는데 마찬가지입니다ㅜ
- 모달에서 다른 화면으로 넘어가는 것도 구현한 다음 풀리퀘를 올리고 싶었지만 잘 되지 않아 이 상태로 풀리퀘 올립니다..ㅠ
## 📸 스크린샷

https://user-images.githubusercontent.com/25932970/199002060-261e92c3-c87c-4405-957b-f2edc161bf30.mov
- 메인 화면에서부터 게임으로 이어지는 부분도 올리면 좋은데 동영상 용량 문제로 올려지지 않네요ㅜ

## 관련 이슈
- Resolved: #31 