### PR TITLE
[FEAT] 정답 시 모달 등장 및 소리 출력

### DIFF
--- a/FindDict/FindDict.xcodeproj/project.pbxproj
+++ b/FindDict/FindDict.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		4D14BD7B28E20CA8002B2165 /* NotoSans-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4D14BD7228E20A8C002B2165 /* NotoSans-Regular.ttf */; };
 		4D53A66A28DAF9C0000E2AA2 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4D53A66928DAF9C0000E2AA2 /* SnapKit */; };
 		4D53A66D28DAF9C8000E2AA2 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 4D53A66C28DAF9C8000E2AA2 /* Then */; };
+		4D6943E42914F11300974B71 /* GuessedRightWordVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6943E32914F11300974B71 /* GuessedRightWordVC.swift */; };
 		4D8E9F3328F001C00013B7E7 /* yolov7.mlmodel in Sources */ = {isa = PBXBuildFile; fileRef = 4D8E9F3228F001C00013B7E7 /* yolov7.mlmodel */; };
 		4D9ADC0728E018DB008CF9F3 /* SignInVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D9ADC0628E018DB008CF9F3 /* SignInVC.swift */; };
 		4DA65AAE28E86914002DEFE3 /* TargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA65AAD28E86914002DEFE3 /* TargetType.swift */; };
@@ -69,7 +70,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-
 		4D0B1E1128E5A9A4007F16DB /* GameVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameVC.swift; sourceTree = "<group>"; };
 		4D0B1E1328E5AA2C007F16DB /* yolov5m.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; name = yolov5m.mlmodel; path = "../../../../../../../2022/2022-2/캡스톤 디자인/mlmodel/yolov5m.mlmodel"; sourceTree = "<group>"; };
 		4D0B1E1528E5B213007F16DB /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
@@ -83,7 +83,8 @@
 		4D14BD7428E20A8C002B2165 /* NotoSans-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSans-Medium.ttf"; sourceTree = "<group>"; };
 		4D14BD7528E20A8C002B2165 /* NotoSans-SemiBold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSans-SemiBold.ttf"; sourceTree = "<group>"; };
 		4D14BD7628E20B8D002B2165 /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
-		4D8E9F3228F001C00013B7E7 /* yolov7.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; name = yolov7.mlmodel; path = ../../../../../../../../Downloads/yolov7.mlmodel; sourceTree = "<group>"; };
+		4D6943E32914F11300974B71 /* GuessedRightWordVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuessedRightWordVC.swift; sourceTree = "<group>"; };
+		4D8E9F3228F001C00013B7E7 /* yolov7.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; name = yolov7.mlmodel; path = "../../../../../../../2022/2022-2/캡스톤 디자인/mlmodel/yolov7.mlmodel"; sourceTree = "<group>"; };
 		4D9ADC0628E018DB008CF9F3 /* SignInVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInVC.swift; sourceTree = "<group>"; };
 		4DA65AAD28E86914002DEFE3 /* TargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetType.swift; sourceTree = "<group>"; };
 		4DA65AB228E86A7A002DEFE3 /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
@@ -162,6 +163,7 @@
 				4D0B1E1328E5AA2C007F16DB /* yolov5m.mlmodel */,
 				4D0B1E1128E5A9A4007F16DB /* GameVC.swift */,
 				4DF76EBB290A680F00AA79D2 /* TargetListComponentView.swift */,
+				4D6943E32914F11300974B71 /* GuessedRightWordVC.swift */,
 				4D0B1E1728E6D5BA007F16DB /* DrawingBoundingBoxView.swift */,
 				F82979BD28EEB1ED0031BBC3 /* GameResultModal */,
 				F8E32BB3290FCAB9009B0749 /* HintModalVC.swift */,
@@ -510,6 +512,7 @@
 				F8823AA128DFE99200798374 /* SignUpVC.swift in Sources */,
 				F8823AA928E575D300798374 /* MainButton.swift in Sources */,
 				F860B79D28E6CFBC0032A39B /* DictionaryVC.swift in Sources */,
+				4D6943E42914F11300974B71 /* GuessedRightWordVC.swift in Sources */,
 				4D9ADC0728E018DB008CF9F3 /* SignInVC.swift in Sources */,
 				4DA65AC228E86B6B002DEFE3 /* SignInAPI.swift in Sources */,
 				4DA65AB628E86AB0002DEFE3 /* APIConstants.swift in Sources */,
@@ -665,7 +668,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 3BJK5D777T;
+				DEVELOPMENT_TEAM = T24N5ZR2DS;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FindDict/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Find Dict";
@@ -698,7 +701,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 3BJK5D777T;
+				DEVELOPMENT_TEAM = T24N5ZR2DS;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FindDict/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Find Dict";

--- a/FindDict/FindDict.xcodeproj/project.pbxproj
+++ b/FindDict/FindDict.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		4D53A66A28DAF9C0000E2AA2 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4D53A66928DAF9C0000E2AA2 /* SnapKit */; };
 		4D53A66D28DAF9C8000E2AA2 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 4D53A66C28DAF9C8000E2AA2 /* Then */; };
 		4D6943E42914F11300974B71 /* GuessedRightWordVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6943E32914F11300974B71 /* GuessedRightWordVC.swift */; };
+		4D6943E6291518EF00974B71 /* SpeechButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6943E5291518EF00974B71 /* SpeechButton.swift */; };
 		4D8E9F3328F001C00013B7E7 /* yolov7.mlmodel in Sources */ = {isa = PBXBuildFile; fileRef = 4D8E9F3228F001C00013B7E7 /* yolov7.mlmodel */; };
 		4D9ADC0728E018DB008CF9F3 /* SignInVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D9ADC0628E018DB008CF9F3 /* SignInVC.swift */; };
 		4DA65AAE28E86914002DEFE3 /* TargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA65AAD28E86914002DEFE3 /* TargetType.swift */; };
@@ -84,6 +85,7 @@
 		4D14BD7528E20A8C002B2165 /* NotoSans-SemiBold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSans-SemiBold.ttf"; sourceTree = "<group>"; };
 		4D14BD7628E20B8D002B2165 /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
 		4D6943E32914F11300974B71 /* GuessedRightWordVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuessedRightWordVC.swift; sourceTree = "<group>"; };
+		4D6943E5291518EF00974B71 /* SpeechButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechButton.swift; sourceTree = "<group>"; };
 		4D8E9F3228F001C00013B7E7 /* yolov7.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; name = yolov7.mlmodel; path = "../../../../../../../2022/2022-2/캡스톤 디자인/mlmodel/yolov7.mlmodel"; sourceTree = "<group>"; };
 		4D9ADC0628E018DB008CF9F3 /* SignInVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInVC.swift; sourceTree = "<group>"; };
 		4DA65AAD28E86914002DEFE3 /* TargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetType.swift; sourceTree = "<group>"; };
@@ -328,6 +330,7 @@
 				4D14BD6928E1C0F9002B2165 /* TextField.swift */,
 				4DF76EB7290A61FF00AA79D2 /* GameResultButton.swift */,
 				4D14BD7028E206BA002B2165 /* PhotoSelectorButton.swift */,
+				4D6943E5291518EF00974B71 /* SpeechButton.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -489,6 +492,7 @@
 				4D14BD6A28E1C0F9002B2165 /* TextField.swift in Sources */,
 				F8DB7A6028DB2E8600EE3D66 /* AuthBaseVC.swift in Sources */,
 				4DA65AB828E86ABB002DEFE3 /* GenericResponse.swift in Sources */,
+				4D6943E6291518EF00974B71 /* SpeechButton.swift in Sources */,
 				4D0B1E1228E5A9A4007F16DB /* GameVC.swift in Sources */,
 				F8DB7A5C28DB1FA700EE3D66 /* UIView+.swift in Sources */,
 				4D14BD6F28E2068B002B2165 /* PhotoSelectorVC.swift in Sources */,

--- a/FindDict/FindDict/Global/Extensions/UIFont+.swift
+++ b/FindDict/FindDict/Global/Extensions/UIFont+.swift
@@ -48,36 +48,7 @@ extension UIFont {
         return UIFont(name: "NotoSans-Bold", size: 15.0)!
     }
     
-    //    class var mumentB2B14: UIFont {
-    //        return UIFont(name: "NotoSans-Bold", size: 14.0)!
-    //    }
-    //
-    //    class var mumentB3M14: UIFont {
-    //        return UIFont(name: "NotoSans-Medium", size: 14.0)!
-    //    }
-    //
-    //    class var mumentB4M14: UIFont {
-    //        return UIFont(name: "NotoSans-Medium", size: 14.0)!
-    //    }
-    //
-    //    class var mumentB5B13: UIFont {
-    //        return UIFont(name: "NotoSans-Bold", size: 13.0)!
-    //    }
-    //
-    //    class var mumentB6M13: UIFont {
-    //        return UIFont(name: "NotoSans-Medium", size: 13.0)!
-    //    }
-    //
     class var findDictB7R12: UIFont {
         return UIFont(name: "NotoSans-Regular", size: 12.0)!
     }
-    //
-    //    class var mumentB8M12: UIFont {
-    //        return UIFont(name: "NotoSans-Medium", size: 12.0)!
-    //    }
-    //
-    //    class var mumentC1R12: UIFont {
-    //        return UIFont(name: "NotoSans-Regular", size: 12.0)!
-    //    }
-    
 }

--- a/FindDict/FindDict/Sources/Components/SpeechButton.swift
+++ b/FindDict/FindDict/Sources/Components/SpeechButton.swift
@@ -1,0 +1,29 @@
+//
+//  speechButton.swift
+//  FindDict
+//
+//  Created by 김지민 on 2022/11/04.
+//
+
+import UIKit
+
+class SpeechButton: UIButton {
+    
+
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        setUI()
+    }
+    
+    required init(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)!
+        setUI()
+    }
+
+    func setUI(){
+        self.titleLabel?.font = .findDictH4R24
+        self.setTitleColor(.black, for: .normal)
+        self.layer.cornerRadius = 20
+        self.backgroundColor = .modalButtonLightYellow
+    }
+}

--- a/FindDict/FindDict/Sources/Components/SpeechButton.swift
+++ b/FindDict/FindDict/Sources/Components/SpeechButton.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class SpeechButton: UIButton {
     
-
+    // MARK: - View Life Cycle
     override init(frame: CGRect) {
         super.init(frame: .zero)
         setUI()
@@ -20,6 +20,7 @@ class SpeechButton: UIButton {
         setUI()
     }
 
+    // MARK: - Functions
     func setUI(){
         self.titleLabel?.font = .findDictH4R24
         self.setTitleColor(.black, for: .normal)

--- a/FindDict/FindDict/Sources/Scences/Game/GameVC.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/GameVC.swift
@@ -49,14 +49,20 @@ class GameVC:ViewController {
     private var colors: [String: UIColor] = [:]
     private var theNumberOfTargetsGuessedRight = 0 {
         didSet{
+            print(theNumberOfTargetsGuessedRight)
             if theNumberOfTargetsGuessedRight == wordTargets.count {
-                let gameResultSuccessVC = GameResultSuccessVC(navigationController: self.navigationController)
-                gameResultSuccessVC.modalPresentationStyle = .overCurrentContext
-                self.present(gameResultSuccessVC, animated: true)
+//                self.dismiss(animated: true) {
+                print(theNumberOfTargetsGuessedRight)
+                    let gameResultSuccessVC = GameResultSuccessVC(navigationController: self.navigationController)
+                    gameResultSuccessVC.modalPresentationStyle = .overCurrentContext
+                    self.present(gameResultSuccessVC, animated: true)
+//                }
             }
         }
     }
-    
+    func increasetheNumberOfTargetsGuessedRight(){
+        self.theNumberOfTargetsGuessedRight += 1
+    }
     // MARK: - UI Properties
     private let logoImage = UIImageView().then{
         $0.contentMode = .scaleAspectFit
@@ -93,8 +99,8 @@ class GameVC:ViewController {
                     button.isUserInteractionEnabled = false
                     self.disableButtons(label:button.titleLabel?.text ?? "레이블 오류")
                     self.handleGuessedRightView(label:button.titleLabel?.text ?? "레이블 오류")
-                    self.theNumberOfTargetsGuessedRight += 1
                     self.presentGuessedRightWordModal(text:button.titleLabel?.text ?? "레이블 오류")
+                    
                 }
                 buttonLayer.addSubview(button)
             }
@@ -196,6 +202,7 @@ class GameVC:ViewController {
         let guessedRightWordVC = GuessedRightWordVC()
         guessedRightWordVC.setEnglishText(text: text)
         guessedRightWordVC.modalPresentationStyle = .overCurrentContext
+        guessedRightWordVC.presentingVC = self
         self.present(guessedRightWordVC, animated: true)
     }
 }

--- a/FindDict/FindDict/Sources/Scences/Game/GameVC.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/GameVC.swift
@@ -51,8 +51,6 @@ class GameVC:ViewController {
         didSet{
             if theNumberOfTargetsGuessedRight == wordTargets.count {
                 let gameResultSuccessVC = GameResultSuccessVC(navigationController: self.navigationController)
-//                gameResultSuccessVC.modalTransitionStyle = .crossDissolve
-//                gameResultSuccessVC.modalPresentationStyle = .overFullScreen
                 gameResultSuccessVC.modalPresentationStyle = .overCurrentContext
                 self.present(gameResultSuccessVC, animated: true)
             }
@@ -96,6 +94,7 @@ class GameVC:ViewController {
                     self.disableButtons(label:button.titleLabel?.text ?? "레이블 오류")
                     self.handleGuessedRightView(label:button.titleLabel?.text ?? "레이블 오류")
                     self.theNumberOfTargetsGuessedRight += 1
+                    self.presentGuessedRightWordModal(text:button.titleLabel?.text ?? "레이블 오류")
                 }
                 buttonLayer.addSubview(button)
             }
@@ -191,6 +190,13 @@ class GameVC:ViewController {
                 wordTarget.handleGussedRightView()
             }
         }
+    }
+    
+    private func presentGuessedRightWordModal(text: String){
+        let guessedRightWordVC = GuessedRightWordVC()
+        guessedRightWordVC.setEnglishText(text: text)
+        guessedRightWordVC.modalPresentationStyle = .overCurrentContext
+        self.present(guessedRightWordVC, animated: true)
     }
 }
 

--- a/FindDict/FindDict/Sources/Scences/Game/GameVC.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/GameVC.swift
@@ -51,12 +51,9 @@ class GameVC:ViewController {
         didSet{
             print(theNumberOfTargetsGuessedRight)
             if theNumberOfTargetsGuessedRight == wordTargets.count {
-//                self.dismiss(animated: true) {
-                print(theNumberOfTargetsGuessedRight)
-                    let gameResultSuccessVC = GameResultSuccessVC(navigationController: self.navigationController)
-                    gameResultSuccessVC.modalPresentationStyle = .overCurrentContext
-                    self.present(gameResultSuccessVC, animated: true)
-//                }
+                let gameResultSuccessVC = GameResultSuccessVC(navigationController: self.navigationController)
+                gameResultSuccessVC.modalPresentationStyle = .overCurrentContext
+                self.present(gameResultSuccessVC, animated: true)
             }
         }
     }
@@ -93,7 +90,7 @@ class GameVC:ViewController {
     private lazy var buttons: [UIButton] = [] {
         didSet{
             for button in buttons {
-                button.press{ [self] in 
+                button.press{ [self] in
                     button.setImage(UIImage(named: "icon"), for: .normal)
                     button.imageView?.contentMode = .scaleAspectFit
                     button.isUserInteractionEnabled = false
@@ -107,7 +104,6 @@ class GameVC:ViewController {
         }
     }
     
-    // TODO: 모든 객체 리스트 비활성화됐을 경우 게임 종료
     // TODO: 버튼 부분 아닌 곳 클릭했을 경우 x표시 나타나기
     
     
@@ -136,7 +132,6 @@ class GameVC:ViewController {
             
         }
         wordTargets = createdTargets
-//        numberOfTargetWords = wordTargets.count
     }
     
     /// 인식된 객체마다 이에 맞는 버튼을 생성합니다.

--- a/FindDict/FindDict/Sources/Scences/Game/GuessedRightWordVC.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/GuessedRightWordVC.swift
@@ -20,7 +20,7 @@ class GuessedRightWordVC: UIViewController {
     private var englishText:String = ""{
         didSet{
             englishLabel.text = englishText
-            printOutSpeech()
+            printOutAmericanSpeech()
         }
     }
     private let synthesizer = AVSpeechSynthesizer()
@@ -37,6 +37,22 @@ class GuessedRightWordVC: UIViewController {
         $0.setImage(UIImage(named: "closeImage"), for: .normal)
     }
     
+    private let americanSpeeachButton = UIButton().then{
+        $0.setTitle("🗣🇺🇸", for: .normal)
+    }
+    private let englishSpeeachButton = UIButton().then{
+        $0.setTitle("🗣🇬🇧", for: .normal)
+    }
+    private let australianSpeeachButton = UIButton().then{
+        $0.setTitle("🗣🇦🇺", for: .normal)
+    }
+    
+    private lazy var buttonStackView = UIStackView(arrangedSubviews: [americanSpeeachButton,englishSpeeachButton,australianSpeeachButton]).then{
+        $0.axis = .horizontal
+        $0.spacing = 33
+    }
+    
+    
     var presentingVC:UIViewController?
     
     override func viewDidLoad() {
@@ -50,27 +66,44 @@ class GuessedRightWordVC: UIViewController {
         englishText = text
     }
     
-    private func printOutSpeech(){
-        let utterance = AVSpeechUtterance(string: englishText)
-        utterance.voice = AVSpeechSynthesisVoice(language: "en-US")
-        utterance.rate = 0.4
-        synthesizer.speak(utterance)
-    }
-    
     private func setButtonActions(){
         closeButton.press{
             guard let pvc = self.presentingVC as? GameVC else {return}
             pvc.dismiss(animated: true){
                 pvc.increasetheNumberOfTargetsGuessedRight()
             }
-//            self.dismiss(animated: true) {
-//                guard let pvc = self.presentingViewController else { return }
-//                pvc.increasetheNumberOfTargetsGuessedRight()
-                
-//                let gameVC = GameVC()
-//                gameVC.increasetheNumberOfTargetsGuessedRight()
-//            }
         }
+        americanSpeeachButton.press{
+            self.printOutAmericanSpeech()
+        }
+        englishSpeeachButton.press{
+            self.printOutEnglishSpeech()
+        }
+        australianSpeeachButton.press{
+            self.printOutAustralianSpeech()
+        }
+    }
+    
+    private func printOutAmericanSpeech(){
+        let utterance = AVSpeechUtterance(string: englishText)
+        utterance.voice = AVSpeechSynthesisVoice(language: "en-US")
+        //        utterance.voice?.gender = .female
+        utterance.rate = 0.4
+        synthesizer.speak(utterance)
+    }
+    
+    private func printOutEnglishSpeech(){
+        let utterance = AVSpeechUtterance(string: englishText)
+        utterance.voice = AVSpeechSynthesisVoice(language: "en-GB")
+        utterance.rate = 0.4
+        synthesizer.speak(utterance)
+    }
+    
+    private func printOutAustralianSpeech(){
+        let utterance = AVSpeechUtterance(string: englishText)
+        utterance.voice = AVSpeechSynthesisVoice(language: "en-AU")
+        utterance.rate = 0.4
+        synthesizer.speak(utterance)
     }
 }
 
@@ -78,7 +111,7 @@ class GuessedRightWordVC: UIViewController {
 // MARK: - UI
 extension GuessedRightWordVC {
     private func setLayout() {
-        view.addSubViews([modalView, englishLabel, closeButton])
+        view.addSubViews([modalView, englishLabel, closeButton,buttonStackView])
         
         modalView.snp.makeConstraints{
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(236)
@@ -93,7 +126,11 @@ extension GuessedRightWordVC {
         closeButton.snp.makeConstraints{
             $0.top.equalTo(modalView.snp.top).offset(16)
             $0.trailing.equalTo(modalView.snp.trailing).inset(20)
-      
+            
+        }
+        buttonStackView.snp.makeConstraints{
+            $0.top.equalTo(englishLabel.snp.bottom).offset(30)
+            $0.centerX.equalTo(modalView)
         }
         
     }

--- a/FindDict/FindDict/Sources/Scences/Game/GuessedRightWordVC.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/GuessedRightWordVC.swift
@@ -12,8 +12,11 @@ import Then
 
 class GuessedRightWordVC: UIViewController {
     
-    
-    private let englishLabel = UILabel()
+    // MARK: - Properties
+    private let englishLabel = UILabel().then{
+        $0.font = .findDictH4R35
+        $0.textColor = .black
+    }
     private var englishText:String = ""{
         didSet{
             englishLabel.text = englishText
@@ -21,12 +24,25 @@ class GuessedRightWordVC: UIViewController {
         }
     }
     private let synthesizer = AVSpeechSynthesizer()
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        // Do any additional setup after loading the view.
+    
+    private let modalView = UIView().then{
+        $0.backgroundColor = .bgBeige
+        $0.layer.shadowRadius = 4
+        $0.layer.shadowOffset = CGSize(width: 0, height: 4)
+        $0.layer.shadowColor = UIColor.black.cgColor
+        $0.layer.shadowOpacity = 0.25
     }
     
+    private let closeButton = UIButton().then{
+        $0.setImage(UIImage(named: "closeImage"), for: .normal)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .bgModal
+        setLayout()
+        setButtonActions()
+    }
     
     func setEnglishText(text:String){
         englishText = text
@@ -37,5 +53,36 @@ class GuessedRightWordVC: UIViewController {
         utterance.voice = AVSpeechSynthesisVoice(language: "en-US")
         utterance.rate = 0.4
         synthesizer.speak(utterance)
+    }
+    
+    private func setButtonActions(){
+        closeButton.press{
+            self.dismiss(animated: true, completion: nil)
+        }
+    }
+}
+
+
+// MARK: - UI
+extension GuessedRightWordVC {
+    private func setLayout() {
+        view.addSubViews([modalView, englishLabel, closeButton])
+        
+        modalView.snp.makeConstraints{
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(236)
+            $0.leading.equalTo(view.safeAreaLayoutGuide.snp.leading).offset(223)
+            $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).inset(223)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(92)
+        }
+        englishLabel.snp.makeConstraints{
+            $0.top.equalTo(modalView.snp.top).offset(40)
+            $0.centerX.equalTo(modalView)
+        }
+        closeButton.snp.makeConstraints{
+            $0.top.equalTo(modalView.snp.top).offset(16)
+            $0.trailing.equalTo(modalView.snp.trailing).inset(20)
+      
+        }
+        
     }
 }

--- a/FindDict/FindDict/Sources/Scences/Game/GuessedRightWordVC.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/GuessedRightWordVC.swift
@@ -13,17 +13,18 @@ import Then
 class GuessedRightWordVC: UIViewController {
     
     // MARK: - Properties
-    private let englishLabel = UILabel().then{
+    private let englishLabel = UILabel().then {
         $0.font = .findDictH4R35
         $0.textColor = .black
-//        $0.sizeToFit()
     }
-    private var englishText:String = ""{
+    
+    private var englishText : String = "" {
         didSet{
             englishLabel.text = englishText
             printOutAmericanSpeech()
         }
     }
+    
     private let synthesizer = AVSpeechSynthesizer()
     
     private let modalView = UIView().then{
@@ -54,9 +55,9 @@ class GuessedRightWordVC: UIViewController {
         $0.distribution = .fillEqually
     }
     
-    
     var presentingVC:UIViewController?
     
+    // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .bgModal
@@ -64,6 +65,7 @@ class GuessedRightWordVC: UIViewController {
         setButtonActions()
     }
     
+    // MARK: - Functions
     func setEnglishText(text:String){
         englishText = text
     }
@@ -75,12 +77,15 @@ class GuessedRightWordVC: UIViewController {
                 pvc.increasetheNumberOfTargetsGuessedRight()
             }
         }
+        
         americanSpeeachButton.press{
             self.printOutAmericanSpeech()
         }
+        
         englishSpeeachButton.press{
             self.printOutEnglishSpeech()
         }
+        
         australianSpeeachButton.press{
             self.printOutAustralianSpeech()
         }
@@ -89,7 +94,6 @@ class GuessedRightWordVC: UIViewController {
     private func printOutAmericanSpeech(){
         let utterance = AVSpeechUtterance(string: englishText)
         utterance.voice = AVSpeechSynthesisVoice(language: "en-US")
-        //        utterance.voice?.gender = .female
         utterance.rate = 0.4
         synthesizer.speak(utterance)
     }
@@ -131,30 +135,13 @@ extension GuessedRightWordVC {
         closeButton.snp.makeConstraints{
             $0.top.equalTo(modalView.snp.top).offset(16)
             $0.trailing.equalTo(modalView.snp.trailing).inset(20)
-            
         }
         
         buttonStackView.snp.makeConstraints{
             $0.top.equalTo(englishLabel.snp.bottom).offset(30)
-//            $0.centerX.equalTo(modalView)
             $0.leading.equalTo(modalView.snp.leading).offset(30)
             $0.trailing.equalTo(modalView.snp.trailing).inset(30)
             $0.bottom.equalTo(modalView.snp.bottom).inset(30)
-//            $0.centerY.equalTo(modalView)
-            
         }
-//
-//        americanSpeeachButton.snp.makeConstraints{
-//            $0.height.equalTo(40)
-//        }
-//
-//        englishSpeeachButton.snp.makeConstraints{
-//            $0.height.equalTo(40)
-//
-//        }
-//        australianSpeeachButton.snp.makeConstraints{
-//            $0.height.equalTo(40)
-//        }
-        
     }
 }

--- a/FindDict/FindDict/Sources/Scences/Game/GuessedRightWordVC.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/GuessedRightWordVC.swift
@@ -16,6 +16,7 @@ class GuessedRightWordVC: UIViewController {
     private let englishLabel = UILabel().then{
         $0.font = .findDictH4R35
         $0.textColor = .black
+//        $0.sizeToFit()
     }
     private var englishText:String = ""{
         didSet{
@@ -37,19 +38,20 @@ class GuessedRightWordVC: UIViewController {
         $0.setImage(UIImage(named: "closeImage"), for: .normal)
     }
     
-    private let americanSpeeachButton = UIButton().then{
-        $0.setTitle("🗣🇺🇸", for: .normal)
+    private let americanSpeeachButton = SpeechButton().then{
+        $0.setTitle("🇺🇸 미국식 발음으로 듣기", for: .normal)
     }
-    private let englishSpeeachButton = UIButton().then{
-        $0.setTitle("🗣🇬🇧", for: .normal)
+    private let englishSpeeachButton = SpeechButton().then{
+        $0.setTitle("🇬🇧 영국식 발음으로 듣기", for: .normal)
     }
-    private let australianSpeeachButton = UIButton().then{
-        $0.setTitle("🗣🇦🇺", for: .normal)
+    private let australianSpeeachButton = SpeechButton().then{
+        $0.setTitle("🇦🇺 호주식 발음으로 듣기", for: .normal)
     }
     
     private lazy var buttonStackView = UIStackView(arrangedSubviews: [americanSpeeachButton,englishSpeeachButton,australianSpeeachButton]).then{
-        $0.axis = .horizontal
-        $0.spacing = 33
+        $0.axis = .vertical
+        $0.spacing = 15
+        $0.distribution = .fillEqually
     }
     
     
@@ -111,7 +113,7 @@ class GuessedRightWordVC: UIViewController {
 // MARK: - UI
 extension GuessedRightWordVC {
     private func setLayout() {
-        view.addSubViews([modalView, englishLabel, closeButton,buttonStackView])
+        view.addSubViews([modalView, englishLabel, closeButton, buttonStackView])
         
         modalView.snp.makeConstraints{
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(236)
@@ -119,19 +121,40 @@ extension GuessedRightWordVC {
             $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).inset(223)
             $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(92)
         }
+        
         englishLabel.snp.makeConstraints{
             $0.top.equalTo(modalView.snp.top).offset(40)
             $0.centerX.equalTo(modalView)
+            $0.height.equalTo(50)
         }
+        
         closeButton.snp.makeConstraints{
             $0.top.equalTo(modalView.snp.top).offset(16)
             $0.trailing.equalTo(modalView.snp.trailing).inset(20)
             
         }
+        
         buttonStackView.snp.makeConstraints{
             $0.top.equalTo(englishLabel.snp.bottom).offset(30)
-            $0.centerX.equalTo(modalView)
+//            $0.centerX.equalTo(modalView)
+            $0.leading.equalTo(modalView.snp.leading).offset(30)
+            $0.trailing.equalTo(modalView.snp.trailing).inset(30)
+            $0.bottom.equalTo(modalView.snp.bottom).inset(30)
+//            $0.centerY.equalTo(modalView)
+            
         }
+//
+//        americanSpeeachButton.snp.makeConstraints{
+//            $0.height.equalTo(40)
+//        }
+//
+//        englishSpeeachButton.snp.makeConstraints{
+//            $0.height.equalTo(40)
+//
+//        }
+//        australianSpeeachButton.snp.makeConstraints{
+//            $0.height.equalTo(40)
+//        }
         
     }
 }

--- a/FindDict/FindDict/Sources/Scences/Game/GuessedRightWordVC.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/GuessedRightWordVC.swift
@@ -37,6 +37,8 @@ class GuessedRightWordVC: UIViewController {
         $0.setImage(UIImage(named: "closeImage"), for: .normal)
     }
     
+    var presentingVC:UIViewController?
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .bgModal
@@ -57,7 +59,17 @@ class GuessedRightWordVC: UIViewController {
     
     private func setButtonActions(){
         closeButton.press{
-            self.dismiss(animated: true, completion: nil)
+            guard let pvc = self.presentingVC as? GameVC else {return}
+            pvc.dismiss(animated: true){
+                pvc.increasetheNumberOfTargetsGuessedRight()
+            }
+//            self.dismiss(animated: true) {
+//                guard let pvc = self.presentingViewController else { return }
+//                pvc.increasetheNumberOfTargetsGuessedRight()
+                
+//                let gameVC = GameVC()
+//                gameVC.increasetheNumberOfTargetsGuessedRight()
+//            }
         }
     }
 }

--- a/FindDict/FindDict/Sources/Scences/Game/GuessedRightWordVC.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/GuessedRightWordVC.swift
@@ -1,0 +1,41 @@
+//
+//  GuessedRightWordVC.swift
+//  FindDict
+//
+//  Created by 김지민 on 2022/11/04.
+//
+
+import UIKit
+import AVFoundation
+import SnapKit
+import Then
+
+class GuessedRightWordVC: UIViewController {
+    
+    
+    private let englishLabel = UILabel()
+    private var englishText:String = ""{
+        didSet{
+            englishLabel.text = englishText
+            printOutSpeech()
+        }
+    }
+    private let synthesizer = AVSpeechSynthesizer()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+    }
+    
+    
+    func setEnglishText(text:String){
+        englishText = text
+    }
+    
+    private func printOutSpeech(){
+        let utterance = AVSpeechUtterance(string: englishText)
+        utterance.voice = AVSpeechSynthesisVoice(language: "en-US")
+        utterance.rate = 0.4
+        synthesizer.speak(utterance)
+    }
+}

--- a/FindDict/FindDict/Sources/Scences/Game/TargetListComponentView.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/TargetListComponentView.swift
@@ -11,8 +11,6 @@ import Then
 
 class TargetListComponentView: UIView {
     
-    private var guessedRight = true
-
     private let koreanButton = UIButton().then{
         if #available(iOS 15.0, *) {
             $0.configuration = .plain()
@@ -28,43 +26,43 @@ class TargetListComponentView: UIView {
     }
     
     private let englishLabelBoundaryView = UIView().then {
-//        $0.addShadow(location: .bottom)
-//                $0.addShadow(location: .left)
-//                $0.addShadow(location: .right)
-//        $0.addShadow(offset: CGSize(width: 0, height: -2),opacity: 0.2,radius: 2.0)
+        //        $0.addShadow(location: .bottom)
+        //                $0.addShadow(location: .left)
+        //                $0.addShadow(location: .right)
+        //        $0.addShadow(offset: CGSize(width: 0, height: -2),opacity: 0.2,radius: 2.0)
         $0.layer.shadowRadius = 4
-                $0.layer.shadowOffset = CGSize(width: 0, height: 4)
-                $0.layer.shadowColor = UIColor.black.cgColor
-                $0.layer.shadowOpacity = 0.25
+        $0.layer.shadowOffset = CGSize(width: 0, height: 4)
+        $0.layer.shadowColor = UIColor.black.cgColor
+        $0.layer.shadowOpacity = 0.25
         $0.backgroundColor = .white
         $0.makeRounded(cornerRadius: 15)
     }
     
     private let englishLabel = UILabel().then{
-//        $0.addShadow(location: .bottom)
-//        $0.addShadow(location: .left)
-//        $0.addShadow(location: .right)
-//        $0.addShadow(offset: CGSize(width: 0, height: -2),opacity: 0.2,radius: 2.0)
-//        $0.shadowColor
-//        $0.shadowColor = .black
-//        $0.shadowOffset = CGSize(width: 0, height: 4)
+        //        $0.addShadow(location: .bottom)
+        //        $0.addShadow(location: .left)
+        //        $0.addShadow(location: .right)
+        //        $0.addShadow(offset: CGSize(width: 0, height: -2),opacity: 0.2,radius: 2.0)
+        //        $0.shadowColor
+        //        $0.shadowColor = .black
+        //        $0.shadowOffset = CGSize(width: 0, height: 4)
         
-//        $0.layer.shadowRadius = 4
-//        $0.layer.shadowOffset = CGSize(width: 0, height: 4)
-//        $0.layer.shadowColor = UIColor.black.cgColor
-//        $0.layer.shadowOpacity = 0.25
-//        $0.makeRounded(cornerRadius: 15)
-//        $0.sizeToFit()
+        //        $0.layer.shadowRadius = 4
+        //        $0.layer.shadowOffset = CGSize(width: 0, height: 4)
+        //        $0.layer.shadowColor = UIColor.black.cgColor
+        //        $0.layer.shadowOpacity = 0.25
+        //        $0.makeRounded(cornerRadius: 15)
+        //        $0.sizeToFit()
         $0.textAlignment = .center
-//        $0.backgroundColor = .white
+        //        $0.backgroundColor = .white
         $0.textColor = .black
         $0.text = "-"
-//
-//        $0.addShadow(location: .bottom)
-//                $0.addShadow(location: .left)
-//                $0.addShadow(location: .right)
-//        $0.backgroundColor = .white
-//        $0.makeRounded(cornerRadius: 15)
+        //
+        //        $0.addShadow(location: .bottom)
+        //                $0.addShadow(location: .left)
+        //                $0.addShadow(location: .right)
+        //        $0.backgroundColor = .white
+        //        $0.makeRounded(cornerRadius: 15)
     }
     
     private var englishLabelText :String = ""
@@ -101,7 +99,7 @@ class TargetListComponentView: UIView {
         englishLabel.text = englishLabelText
         koreanButton.backgroundColor = .buttonGray
     }
-
+    
 }
 
 extension TargetListComponentView {


### PR DESCRIPTION
## 작업한 내용
- 정답을 맞췄을 경우 미국식 영어 발음으로 읽어주며 모달이 등장합니다.
- 모달은 해당 영어 단어 레이블, 여러 발음으로의 출력이 가능한 버튼 세 개, 닫기 버튼으로 구성됩니다. 

## PR Point
- 모달을 열고 닫는 과정에서 맞힌 단어의 개수를 세어 게임 종료 모달을 띄우는 기존 로직과 꼬이는 문제가 있어 일부 로직을 수정했습니다. 
  - 맞힌 단어 개수 갱신을 영어 단어 발음 출력 모달을 닫을 때 하도록 하였습니다.
  - 모달에 presentingVC 프로퍼티를 받아 모달이 열릴 때 이를 여는 VC인 GameVC에서 `guessedRightWordVC.presentingVC = self`를 함으로써 본인 레퍼런스를 전달하고, 모달을 닫을 때 presentingVC의 메소드를 참조하여 맞힌 단어의 개수를 증가시킬 수 있도록 하였습니다.
- 모달에 쓰이는 버튼은 컴포넌트화하여 만들어 사용했습니다. 

## 📸 스크린샷
업로드 가능 용량 제한으로 짧은 두 영상으로 올립니다.
1. 정답 시 모달 등장 및 세 가지 발음으로의 출력

https://user-images.githubusercontent.com/25932970/199953851-f058e50f-dd9e-4cc6-afe4-08b586a884ad.mov


2. 모든 정답 처리 완료 시 게임 성공 모달 등장


https://user-images.githubusercontent.com/25932970/199953981-b87adb1f-28ac-48ee-8c09-4c4766079e84.mov




## 관련 이슈
- Resolved: #37 