### PR TITLE
[FEAT] 단어 리스트 뷰 네트워크 통신 마무리

### DIFF
--- a/FindDict/FindDict.xcodeproj/project.pbxproj
+++ b/FindDict/FindDict.xcodeproj/project.pbxproj
@@ -37,15 +37,13 @@
 		4DA65AC228E86B6B002DEFE3 /* AuthAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA65AC128E86B6A002DEFE3 /* AuthAPI.swift */; };
 		4DA65AC428E86B8C002DEFE3 /* EvenLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA65AC328E86B8C002DEFE3 /* EvenLogger.swift */; };
 		4DA65AC728E86C46002DEFE3 /* SignInBodyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA65AC628E86C46002DEFE3 /* SignInBodyModel.swift */; };
-		4DA65AC928E86CE0002DEFE3 /* SignInDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA65AC828E86CE0002DEFE3 /* SignInDataModel.swift */; };
-		4DB7B499291C08BF000485E1 /* DictionaryDetailVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB7B498291C08BF000485E1 /* DictionaryDetailVC.swift */; };
-		4DB7B49B291C08C6000485E1 /* DictionaryDetailCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB7B49A291C08C6000485E1 /* DictionaryDetailCVC.swift */; };
-
 		4DA65AC928E86CE0002DEFE3 /* SignInResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA65AC828E86CE0002DEFE3 /* SignInResponseModel.swift */; };
 		4DB7B48B291BD338000485E1 /* MessageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB7B48A291BD338000485E1 /* MessageType.swift */; };
 		4DB7B48D291BD803000485E1 /* UserToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB7B48C291BD803000485E1 /* UserToken.swift */; };
 		4DB7B493291BD97F000485E1 /* SignUpBodyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB7B492291BD97F000485E1 /* SignUpBodyModel.swift */; };
 		4DB7B495291BDA33000485E1 /* SignUpResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB7B494291BDA33000485E1 /* SignUpResponseModel.swift */; };
+		4DB7B499291C08BF000485E1 /* DictionaryDetailVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB7B498291C08BF000485E1 /* DictionaryDetailVC.swift */; };
+		4DB7B49B291C08C6000485E1 /* DictionaryDetailCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB7B49A291C08C6000485E1 /* DictionaryDetailCVC.swift */; };
 		4DB7B49D291C1DED000485E1 /* WordListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB7B49C291C1DED000485E1 /* WordListModel.swift */; };
 		4DB7B49F291C1E01000485E1 /* WordListResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB7B49E291C1E01000485E1 /* WordListResponseModel.swift */; };
 		4DB7B4A1291C200F000485E1 /* WordAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB7B4A0291C200F000485E1 /* WordAPI.swift */; };
@@ -59,15 +57,15 @@
 		4DBDEC2C28D4F169002252B3 /* BaseVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBDEC2B28D4F169002252B3 /* BaseVC.swift */; };
 		4DBDEC2F28D4F2B3002252B3 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBDEC2E28D4F2B3002252B3 /* UIViewController+.swift */; };
 		4DBDEC3228D4F308002252B3 /* Colorsets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4DBDEC3128D4F308002252B3 /* Colorsets.xcassets */; };
-		F8560AC228EEF11B00C52203 /* GameTutorialVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8560AC128EEF11B00C52203 /* GameTutorialVC.swift */; };
-		F8560AC428EEF16200C52203 /* GameTutorialCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8560AC328EEF16200C52203 /* GameTutorialCVC.swift */; };
-		F8560AC628EEF17800C52203 /* GameTutorialCVCModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8560AC528EEF17800C52203 /* GameTutorialCVCModel.swift */; };
 		4DEE7166290F53EE000C5D9A /* WordDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DEE7165290F53EE000C5D9A /* WordDictionary.swift */; };
 		4DF76EB8290A61FF00AA79D2 /* GameResultButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF76EB7290A61FF00AA79D2 /* GameResultButton.swift */; };
 		4DF76EBC290A680F00AA79D2 /* TargetListComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF76EBB290A680F00AA79D2 /* TargetListComponentView.swift */; };
 		F82979B728ED5C030031BBC3 /* ModalBaseVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82979B628ED5C030031BBC3 /* ModalBaseVC.swift */; };
 		F82979BF28EEB2220031BBC3 /* GameResultSuccessVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82979BE28EEB2220031BBC3 /* GameResultSuccessVC.swift */; };
 		F82979C128EEC3A40031BBC3 /* GameResultFailVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82979C028EEC3A40031BBC3 /* GameResultFailVC.swift */; };
+		F8560AC228EEF11B00C52203 /* GameTutorialVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8560AC128EEF11B00C52203 /* GameTutorialVC.swift */; };
+		F8560AC428EEF16200C52203 /* GameTutorialCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8560AC328EEF16200C52203 /* GameTutorialCVC.swift */; };
+		F8560AC628EEF17800C52203 /* GameTutorialCVCModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8560AC528EEF17800C52203 /* GameTutorialCVCModel.swift */; };
 		F860B79D28E6CFBC0032A39B /* DictionaryVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F860B79C28E6CFBC0032A39B /* DictionaryVC.swift */; };
 		F860B79F28E7D0AB0032A39B /* DictionaryTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F860B79E28E7D0AB0032A39B /* DictionaryTVC.swift */; };
 		F860B7A128E832DB0032A39B /* UITableViewCell+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F860B7A028E832DB0032A39B /* UITableViewCell+.swift */; };
@@ -76,7 +74,6 @@
 		F8823AA328E022CC00798374 /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8823AA228E022CC00798374 /* UITextField+.swift */; };
 		F8823AA728E5740F00798374 /* MainVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8823AA628E5740F00798374 /* MainVC.swift */; };
 		F8823AA928E575D300798374 /* MainButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8823AA828E575D300798374 /* MainButton.swift */; };
-		F8D9DAD1291B869200AAA355 /* Reusable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D9DAD0291B869200AAA355 /* Reusable.swift */; };
 		F8DB7A5A28DB1D3100EE3D66 /* BeforeSignInVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DB7A5928DB1D3100EE3D66 /* BeforeSignInVC.swift */; };
 		F8DB7A5C28DB1FA700EE3D66 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DB7A5B28DB1FA700EE3D66 /* UIView+.swift */; };
 		F8DB7A5E28DB29F700EE3D66 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DB7A5D28DB29F700EE3D66 /* UIColor+.swift */; };
@@ -113,14 +110,13 @@
 		4DA65AC128E86B6A002DEFE3 /* AuthAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPI.swift; sourceTree = "<group>"; };
 		4DA65AC328E86B8C002DEFE3 /* EvenLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvenLogger.swift; sourceTree = "<group>"; };
 		4DA65AC628E86C46002DEFE3 /* SignInBodyModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInBodyModel.swift; sourceTree = "<group>"; };
-		4DA65AC828E86CE0002DEFE3 /* SignInDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInDataModel.swift; sourceTree = "<group>"; };
-		4DB7B498291C08BF000485E1 /* DictionaryDetailVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryDetailVC.swift; sourceTree = "<group>"; };
-		4DB7B49A291C08C6000485E1 /* DictionaryDetailCVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryDetailCVC.swift; sourceTree = "<group>"; };
 		4DA65AC828E86CE0002DEFE3 /* SignInResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInResponseModel.swift; sourceTree = "<group>"; };
 		4DB7B48A291BD338000485E1 /* MessageType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageType.swift; sourceTree = "<group>"; };
 		4DB7B48C291BD803000485E1 /* UserToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserToken.swift; sourceTree = "<group>"; };
 		4DB7B492291BD97F000485E1 /* SignUpBodyModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpBodyModel.swift; sourceTree = "<group>"; };
 		4DB7B494291BDA33000485E1 /* SignUpResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpResponseModel.swift; sourceTree = "<group>"; };
+		4DB7B498291C08BF000485E1 /* DictionaryDetailVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryDetailVC.swift; sourceTree = "<group>"; };
+		4DB7B49A291C08C6000485E1 /* DictionaryDetailCVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryDetailCVC.swift; sourceTree = "<group>"; };
 		4DB7B49C291C1DED000485E1 /* WordListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordListModel.swift; sourceTree = "<group>"; };
 		4DB7B49E291C1E01000485E1 /* WordListResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordListResponseModel.swift; sourceTree = "<group>"; };
 		4DB7B4A0291C200F000485E1 /* WordAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordAPI.swift; sourceTree = "<group>"; };
@@ -136,15 +132,15 @@
 		4DBDEC2B28D4F169002252B3 /* BaseVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseVC.swift; sourceTree = "<group>"; };
 		4DBDEC2E28D4F2B3002252B3 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		4DBDEC3128D4F308002252B3 /* Colorsets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colorsets.xcassets; sourceTree = "<group>"; };
-		F8560AC128EEF11B00C52203 /* GameTutorialVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameTutorialVC.swift; sourceTree = "<group>"; };
-		F8560AC328EEF16200C52203 /* GameTutorialCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameTutorialCVC.swift; sourceTree = "<group>"; };
-		F8560AC528EEF17800C52203 /* GameTutorialCVCModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameTutorialCVCModel.swift; sourceTree = "<group>"; };
 		4DEE7165290F53EE000C5D9A /* WordDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordDictionary.swift; sourceTree = "<group>"; };
 		4DF76EB7290A61FF00AA79D2 /* GameResultButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GameResultButton.swift; sourceTree = "<group>"; };
 		4DF76EBB290A680F00AA79D2 /* TargetListComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetListComponentView.swift; sourceTree = "<group>"; };
 		F82979B628ED5C030031BBC3 /* ModalBaseVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalBaseVC.swift; sourceTree = "<group>"; };
 		F82979BE28EEB2220031BBC3 /* GameResultSuccessVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameResultSuccessVC.swift; sourceTree = "<group>"; };
 		F82979C028EEC3A40031BBC3 /* GameResultFailVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameResultFailVC.swift; sourceTree = "<group>"; };
+		F8560AC128EEF11B00C52203 /* GameTutorialVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameTutorialVC.swift; sourceTree = "<group>"; };
+		F8560AC328EEF16200C52203 /* GameTutorialCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameTutorialCVC.swift; sourceTree = "<group>"; };
+		F8560AC528EEF17800C52203 /* GameTutorialCVCModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameTutorialCVCModel.swift; sourceTree = "<group>"; };
 		F860B79C28E6CFBC0032A39B /* DictionaryVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryVC.swift; sourceTree = "<group>"; };
 		F860B79E28E7D0AB0032A39B /* DictionaryTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryTVC.swift; sourceTree = "<group>"; };
 		F860B7A028E832DB0032A39B /* UITableViewCell+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+.swift"; sourceTree = "<group>"; };
@@ -400,14 +396,6 @@
 			path = Network;
 			sourceTree = "<group>";
 		};
-		F8560AC728EEF3D500C52203 /* Protocols */ = {
-			isa = PBXGroup;
-			children = (
-				F8D9DAD0291B869200AAA355 /* Reusable.swift */,
-			);
-			path = Protocols;
-			sourceTree = "<group>";
-		};
 		F82979BD28EEB1ED0031BBC3 /* GameResultModal */ = {
 			isa = PBXGroup;
 			children = (
@@ -415,6 +403,14 @@
 				F82979C028EEC3A40031BBC3 /* GameResultFailVC.swift */,
 			);
 			path = GameResultModal;
+			sourceTree = "<group>";
+		};
+		F8560AC728EEF3D500C52203 /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				F8D9DAD0291B869200AAA355 /* Reusable.swift */,
+			);
+			path = Protocols;
 			sourceTree = "<group>";
 		};
 		F860B79B28E6CF870032A39B /* Dictionary */ = {

--- a/FindDict/FindDict.xcodeproj/project.pbxproj
+++ b/FindDict/FindDict.xcodeproj/project.pbxproj
@@ -748,8 +748,8 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -781,8 +781,8 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/FindDict/FindDict.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FindDict/FindDict.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "8dd85aee02e39dd280c75eef88ffdb86eed4b07b",
+        "version" : "5.6.2"
+      }
+    },
+    {
       "identity" : "snapkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SnapKit/SnapKit.git",
@@ -12,7 +21,7 @@
     {
       "identity" : "then",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/devxoul/Then.git",
+      "location" : "https://github.com/devxoul/Then",
       "state" : {
         "branch" : "master",
         "revision" : "d41ef523faef0f911369f79c0b96815d9dbb6d7a"

--- a/FindDict/FindDict/Model/WordListResponseModel.swift
+++ b/FindDict/FindDict/Model/WordListResponseModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct WordListResponseModel: Codable {
-    let words: [Word] = []
+    let words: [Word]
 
     enum CodingKeys: String, CodingKey {
         case words = "words"

--- a/FindDict/FindDict/Sources/Scences/Dictionary/DictionaryCard.swift
+++ b/FindDict/FindDict/Sources/Scences/Dictionary/DictionaryCard.swift
@@ -77,8 +77,6 @@ extension DictionaryCard {
             $0.top.equalTo(self.safeAreaLayoutGuide.snp.top).offset(10)
             $0.leading.equalTo(self.safeAreaLayoutGuide.snp.leading).offset(27)
             $0.bottom.equalTo(self.safeAreaLayoutGuide.snp.bottom).inset(10)
-            $0.height.equalTo(40)
-            $0.width.equalTo(480)
         }
         
         pictureButton.snp.makeConstraints{

--- a/FindDict/FindDict/Sources/Scences/Dictionary/DictionaryTVC.swift
+++ b/FindDict/FindDict/Sources/Scences/Dictionary/DictionaryTVC.swift
@@ -27,12 +27,8 @@ class DictionaryTVC: UITableViewCell {
     }
     
     // MARK: Functions
-    func setData(_ cellData: WordDataModel, cellRowIndex: Int) {
-        dictionaryCard.setData(english: cellData.englishWord, cellRowIndex: cellRowIndex)
-      
-    func setData(_ cellData: WordListResponseModel.Word) {
-        dictionaryCard.koreanWordLabel.text = cellData.korean
-        dictionaryCard.englishWordLabel.text = cellData.english
+    func setData(_ cellData: WordListResponseModel.Word, cellRowIndex: Int) {
+        dictionaryCard.setData(english: cellData.english, cellRowIndex: cellRowIndex)
     }
 }
 

--- a/FindDict/FindDict/Sources/Scences/Dictionary/DictionaryVC.swift
+++ b/FindDict/FindDict/Sources/Scences/Dictionary/DictionaryVC.swift
@@ -9,7 +9,7 @@ import UIKit
 import SnapKit
 import Then
 
-class DictionaryVC: UIViewController {
+final class DictionaryVC: UIViewController {
     
     // MARK: - Properties
     private var dictionaryData: [WordListResponseModel.Word]?
@@ -75,7 +75,6 @@ extension DictionaryVC {
             switch networkResult {
             case .success(let response):
                 if let res = response as? WordListResponseModel {
-                    print(">>>>>>res",res)
                     self.dictionaryData = res.words
                     self.dictionaryTV.reloadData()
                 }
@@ -108,9 +107,8 @@ extension DictionaryVC {
         dictionaryTV.snp.makeConstraints{
             $0.top.equalTo(titleView.snp.bottom).offset(50)
             $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
-            $0.centerX.equalTo(view.safeAreaLayoutGuide)
-            $0.left.equalTo(view.safeAreaLayoutGuide.snp.left).offset(206)
-            $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).offset(-206)
+            $0.leading.equalTo(view.safeAreaLayoutGuide.snp.leading).offset(206)
+            $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).inset(206)
         }
         
         homeButton.snp.makeConstraints{

--- a/FindDict/FindDict/Sources/Scences/Dictionary/DictionaryVC.swift
+++ b/FindDict/FindDict/Sources/Scences/Dictionary/DictionaryVC.swift
@@ -77,12 +77,7 @@ extension DictionaryVC {
                 if let res = response as? WordListResponseModel {
                     print(">>>>>>res",res)
                     self.dictionaryData = res.words
-                    self.setTV()
                     self.dictionaryTV.reloadData()
-                    
-//                    self.dataSource = result
-//                    self.setData()
-//                    self.mumentCardView.setData(result,mumentId: self.mumentId ?? "")
                 }
                 
             default:
@@ -134,12 +129,10 @@ extension DictionaryVC: UITableViewDataSource {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: "DictionaryTVC", for: indexPath) as? DictionaryTVC else {
             return UITableViewCell()
         }
-        
-        cell.setData(WordDataModel.sampleData[indexPath.row], cellRowIndex: indexPath.row)
         cell.dictionaryCard.setDelegate(delegate: self)
       
         let data = dictionaryData?[indexPath.row] ?? WordListResponseModel.sampleData[indexPath.row]
-        cell.setData(data)
+        cell.setData(data, cellRowIndex: indexPath.row)
         return cell
     }
     
@@ -156,10 +149,11 @@ extension DictionaryVC: UITableViewDelegate {
     }
 }
 
+// MARK: - DictionaryCardDelegate
 extension DictionaryVC: DictionaryCardDelegate {
     func wordDetailViewButtonClicked(index: Int) {
         let dictionaryDetailVC = DictionaryDetailVC()
-        dictionaryDetailVC.setWordLabelText(english: WordDataModel.sampleData[index].englishWord)
+        dictionaryDetailVC.setWordLabelText(english: dictionaryData?[index].english ?? WordListResponseModel.sampleData[index].english)
         dictionaryDetailVC.modalPresentationStyle = .overCurrentContext
         self.present(dictionaryDetailVC, animated: true)
     }

--- a/FindDict/FindDict/Sources/Scences/Tutorial/GameTutorialVC.swift
+++ b/FindDict/FindDict/Sources/Scences/Tutorial/GameTutorialVC.swift
@@ -42,7 +42,7 @@ class GameTutorialVC: UIViewController{
     // MARK: - Functions
     func setButtonActions() {
         homeButton.press{
-            let mainView = mainVC()
+            let mainView = MainVC()
             self.navigationController?.pushViewController(mainView, animated: true)
         }
     }


### PR DESCRIPTION
## 작업한 내용
- 단어 리스트 뷰 UI에 네트워크 통신 결과 반영
- 화면 방향 가로 방향으로 고정
- UI 경고 메세지들 해결했습니다

## PR Point
- response 결과를 ResponseModel 로 타입 캐스팅해 가져온 결과 빈 배열로 뜨는 이유가 ResponseModel에서 빈 배열로 초기화했기 때문이었습니다. 이를 삭제하니 데이터가 올바르게 받아와졌습니다. 
- 사진 확인하기 클릭 시 뜨는 모달로 선택한 단어의 레이블이 전달됩니다. 이를 이용해 사진 가져오기 GET 요청을 보내면 됩니다. 

## 📸 스크린샷
![Simulator Screen Recording - iPad Pro (11-inch) (4th generation) - 2022-11-12 at 01 19 52](https://user-images.githubusercontent.com/25932970/201384599-2b432eb1-e658-4c6d-98fa-86f7e9f5d590.gif)


## 관련 이슈
- Resolved: #47
