### PR TITLE
[FEAT] 힌트 모달 연결 및 네트워크 통신 결과 반영

### DIFF
--- a/FindDict/FindDict.xcodeproj/project.pbxproj
+++ b/FindDict/FindDict.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		4D14BD7928E20CA4002B2165 /* NotoSans-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4D14BD7428E20A8C002B2165 /* NotoSans-Medium.ttf */; };
 		4D14BD7A28E20CA6002B2165 /* NotoSans-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4D14BD7528E20A8C002B2165 /* NotoSans-SemiBold.ttf */; };
 		4D14BD7B28E20CA8002B2165 /* NotoSans-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4D14BD7228E20A8C002B2165 /* NotoSans-Regular.ttf */; };
+		4D19F2FC29225532002696D4 /* HintResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D19F2FB29225532002696D4 /* HintResponseModel.swift */; };
 		4D53A66A28DAF9C0000E2AA2 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4D53A66928DAF9C0000E2AA2 /* SnapKit */; };
 		4D53A66D28DAF9C8000E2AA2 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 4D53A66C28DAF9C8000E2AA2 /* Then */; };
 		4D6943E42914F11300974B71 /* GuessedRightWordVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6943E32914F11300974B71 /* GuessedRightWordVC.swift */; };
@@ -55,15 +56,15 @@
 		4DBDEC2C28D4F169002252B3 /* BaseVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBDEC2B28D4F169002252B3 /* BaseVC.swift */; };
 		4DBDEC2F28D4F2B3002252B3 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBDEC2E28D4F2B3002252B3 /* UIViewController+.swift */; };
 		4DBDEC3228D4F308002252B3 /* Colorsets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4DBDEC3128D4F308002252B3 /* Colorsets.xcassets */; };
-		F8560AC228EEF11B00C52203 /* GameTutorialVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8560AC128EEF11B00C52203 /* GameTutorialVC.swift */; };
-		F8560AC428EEF16200C52203 /* GameTutorialCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8560AC328EEF16200C52203 /* GameTutorialCVC.swift */; };
-		F8560AC628EEF17800C52203 /* GameTutorialCVCModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8560AC528EEF17800C52203 /* GameTutorialCVCModel.swift */; };
 		4DEE7166290F53EE000C5D9A /* WordDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DEE7165290F53EE000C5D9A /* WordDictionary.swift */; };
 		4DF76EB8290A61FF00AA79D2 /* GameResultButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF76EB7290A61FF00AA79D2 /* GameResultButton.swift */; };
 		4DF76EBC290A680F00AA79D2 /* TargetListComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF76EBB290A680F00AA79D2 /* TargetListComponentView.swift */; };
 		F82979B728ED5C030031BBC3 /* ModalBaseVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82979B628ED5C030031BBC3 /* ModalBaseVC.swift */; };
 		F82979BF28EEB2220031BBC3 /* GameResultSuccessVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82979BE28EEB2220031BBC3 /* GameResultSuccessVC.swift */; };
 		F82979C128EEC3A40031BBC3 /* GameResultFailVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82979C028EEC3A40031BBC3 /* GameResultFailVC.swift */; };
+		F8560AC228EEF11B00C52203 /* GameTutorialVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8560AC128EEF11B00C52203 /* GameTutorialVC.swift */; };
+		F8560AC428EEF16200C52203 /* GameTutorialCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8560AC328EEF16200C52203 /* GameTutorialCVC.swift */; };
+		F8560AC628EEF17800C52203 /* GameTutorialCVCModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8560AC528EEF17800C52203 /* GameTutorialCVCModel.swift */; };
 		F860B79D28E6CFBC0032A39B /* DictionaryVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F860B79C28E6CFBC0032A39B /* DictionaryVC.swift */; };
 		F860B79F28E7D0AB0032A39B /* DictionaryTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F860B79E28E7D0AB0032A39B /* DictionaryTVC.swift */; };
 		F860B7A128E832DB0032A39B /* UITableViewCell+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F860B7A028E832DB0032A39B /* UITableViewCell+.swift */; };
@@ -72,7 +73,6 @@
 		F8823AA328E022CC00798374 /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8823AA228E022CC00798374 /* UITextField+.swift */; };
 		F8823AA728E5740F00798374 /* MainVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8823AA628E5740F00798374 /* MainVC.swift */; };
 		F8823AA928E575D300798374 /* MainButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8823AA828E575D300798374 /* MainButton.swift */; };
-		F8D9DAD1291B869200AAA355 /* Reusable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D9DAD0291B869200AAA355 /* Reusable.swift */; };
 		F8DB7A5A28DB1D3100EE3D66 /* BeforeSignInVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DB7A5928DB1D3100EE3D66 /* BeforeSignInVC.swift */; };
 		F8DB7A5C28DB1FA700EE3D66 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DB7A5B28DB1FA700EE3D66 /* UIView+.swift */; };
 		F8DB7A5E28DB29F700EE3D66 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DB7A5D28DB29F700EE3D66 /* UIColor+.swift */; };
@@ -95,6 +95,7 @@
 		4D14BD7428E20A8C002B2165 /* NotoSans-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSans-Medium.ttf"; sourceTree = "<group>"; };
 		4D14BD7528E20A8C002B2165 /* NotoSans-SemiBold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSans-SemiBold.ttf"; sourceTree = "<group>"; };
 		4D14BD7628E20B8D002B2165 /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
+		4D19F2FB29225532002696D4 /* HintResponseModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HintResponseModel.swift; sourceTree = "<group>"; };
 		4D6943E32914F11300974B71 /* GuessedRightWordVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuessedRightWordVC.swift; sourceTree = "<group>"; };
 		4D6943E5291518EF00974B71 /* SpeechButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechButton.swift; sourceTree = "<group>"; };
 		4D8E9F3228F001C00013B7E7 /* yolov7.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; name = yolov7.mlmodel; path = "../../../../../../../2022/2022-2/캡스톤 디자인/mlmodel/yolov7.mlmodel"; sourceTree = "<group>"; };
@@ -129,15 +130,15 @@
 		4DBDEC2B28D4F169002252B3 /* BaseVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseVC.swift; sourceTree = "<group>"; };
 		4DBDEC2E28D4F2B3002252B3 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		4DBDEC3128D4F308002252B3 /* Colorsets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colorsets.xcassets; sourceTree = "<group>"; };
-		F8560AC128EEF11B00C52203 /* GameTutorialVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameTutorialVC.swift; sourceTree = "<group>"; };
-		F8560AC328EEF16200C52203 /* GameTutorialCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameTutorialCVC.swift; sourceTree = "<group>"; };
-		F8560AC528EEF17800C52203 /* GameTutorialCVCModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameTutorialCVCModel.swift; sourceTree = "<group>"; };
 		4DEE7165290F53EE000C5D9A /* WordDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordDictionary.swift; sourceTree = "<group>"; };
 		4DF76EB7290A61FF00AA79D2 /* GameResultButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GameResultButton.swift; sourceTree = "<group>"; };
 		4DF76EBB290A680F00AA79D2 /* TargetListComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetListComponentView.swift; sourceTree = "<group>"; };
 		F82979B628ED5C030031BBC3 /* ModalBaseVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalBaseVC.swift; sourceTree = "<group>"; };
 		F82979BE28EEB2220031BBC3 /* GameResultSuccessVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameResultSuccessVC.swift; sourceTree = "<group>"; };
 		F82979C028EEC3A40031BBC3 /* GameResultFailVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameResultFailVC.swift; sourceTree = "<group>"; };
+		F8560AC128EEF11B00C52203 /* GameTutorialVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameTutorialVC.swift; sourceTree = "<group>"; };
+		F8560AC328EEF16200C52203 /* GameTutorialCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameTutorialCVC.swift; sourceTree = "<group>"; };
+		F8560AC528EEF17800C52203 /* GameTutorialCVCModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameTutorialCVCModel.swift; sourceTree = "<group>"; };
 		F860B79C28E6CFBC0032A39B /* DictionaryVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryVC.swift; sourceTree = "<group>"; };
 		F860B79E28E7D0AB0032A39B /* DictionaryTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryTVC.swift; sourceTree = "<group>"; };
 		F860B7A028E832DB0032A39B /* UITableViewCell+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+.swift"; sourceTree = "<group>"; };
@@ -242,6 +243,7 @@
 				4DB7B494291BDA33000485E1 /* SignUpResponseModel.swift */,
 				4DB7B49C291C1DED000485E1 /* WordListModel.swift */,
 				4DB7B49E291C1E01000485E1 /* WordListResponseModel.swift */,
+				4D19F2FB29225532002696D4 /* HintResponseModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -393,14 +395,6 @@
 			path = Network;
 			sourceTree = "<group>";
 		};
-		F8560AC728EEF3D500C52203 /* Protocols */ = {
-			isa = PBXGroup;
-			children = (
-				F8D9DAD0291B869200AAA355 /* Reusable.swift */,
-			);
-			path = Protocols;
-			sourceTree = "<group>";
-		};
 		F82979BD28EEB1ED0031BBC3 /* GameResultModal */ = {
 			isa = PBXGroup;
 			children = (
@@ -408,6 +402,14 @@
 				F82979C028EEC3A40031BBC3 /* GameResultFailVC.swift */,
 			);
 			path = GameResultModal;
+			sourceTree = "<group>";
+		};
+		F8560AC728EEF3D500C52203 /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				F8D9DAD0291B869200AAA355 /* Reusable.swift */,
+			);
+			path = Protocols;
 			sourceTree = "<group>";
 		};
 		F860B79B28E6CF870032A39B /* Dictionary */ = {
@@ -561,6 +563,7 @@
 				4DBDEC2F28D4F2B3002252B3 /* UIViewController+.swift in Sources */,
 				F8560AC628EEF17800C52203 /* GameTutorialCVCModel.swift in Sources */,
 				4DA65AC728E86C46002DEFE3 /* SignInBodyModel.swift in Sources */,
+				4D19F2FC29225532002696D4 /* HintResponseModel.swift in Sources */,
 				F82979B728ED5C030031BBC3 /* ModalBaseVC.swift in Sources */,
 				F8E32BB6290FCBB2009B0749 /* GameResultButton.swift in Sources */,
 				4DEE7166290F53EE000C5D9A /* WordDictionary.swift in Sources */,

--- a/FindDict/FindDict.xcodeproj/project.pbxproj
+++ b/FindDict/FindDict.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		4D14BD7A28E20CA6002B2165 /* NotoSans-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4D14BD7528E20A8C002B2165 /* NotoSans-SemiBold.ttf */; };
 		4D14BD7B28E20CA8002B2165 /* NotoSans-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4D14BD7228E20A8C002B2165 /* NotoSans-Regular.ttf */; };
 		4D19F2FC29225532002696D4 /* HintResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D19F2FB29225532002696D4 /* HintResponseModel.swift */; };
+		4D19F2FE2922579B002696D4 /* UIImageView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D19F2FD2922579A002696D4 /* UIImageView+.swift */; };
 		4D53A66A28DAF9C0000E2AA2 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4D53A66928DAF9C0000E2AA2 /* SnapKit */; };
 		4D53A66D28DAF9C8000E2AA2 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 4D53A66C28DAF9C8000E2AA2 /* Then */; };
 		4D6943E42914F11300974B71 /* GuessedRightWordVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6943E32914F11300974B71 /* GuessedRightWordVC.swift */; };
@@ -96,6 +97,7 @@
 		4D14BD7528E20A8C002B2165 /* NotoSans-SemiBold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSans-SemiBold.ttf"; sourceTree = "<group>"; };
 		4D14BD7628E20B8D002B2165 /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
 		4D19F2FB29225532002696D4 /* HintResponseModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HintResponseModel.swift; sourceTree = "<group>"; };
+		4D19F2FD2922579A002696D4 /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
 		4D6943E32914F11300974B71 /* GuessedRightWordVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuessedRightWordVC.swift; sourceTree = "<group>"; };
 		4D6943E5291518EF00974B71 /* SpeechButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechButton.swift; sourceTree = "<group>"; };
 		4D8E9F3228F001C00013B7E7 /* yolov7.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; name = yolov7.mlmodel; path = "../../../../../../../2022/2022-2/캡스톤 디자인/mlmodel/yolov7.mlmodel"; sourceTree = "<group>"; };
@@ -328,6 +330,7 @@
 				F8823AA228E022CC00798374 /* UITextField+.swift */,
 				4D14BD6728E1B924002B2165 /* UIButton+.swift */,
 				4D14BD7628E20B8D002B2165 /* UIFont+.swift */,
+				4D19F2FD2922579A002696D4 /* UIImageView+.swift */,
 				4D0B1E1528E5B213007F16DB /* UIImage+.swift */,
 				F860B7A028E832DB0032A39B /* UITableViewCell+.swift */,
 			);
@@ -542,6 +545,7 @@
 				F82979C128EEC3A40031BBC3 /* GameResultFailVC.swift in Sources */,
 				F8823AA728E5740F00798374 /* MainVC.swift in Sources */,
 				F860B7A328E835860032A39B /* DictionaryCard.swift in Sources */,
+				4D19F2FE2922579B002696D4 /* UIImageView+.swift in Sources */,
 				F8E32BB4290FCAB9009B0749 /* HintModalVC.swift in Sources */,
 				4DBDEC1428D4EFE2002252B3 /* AppDelegate.swift in Sources */,
 				4DF76EB8290A61FF00AA79D2 /* GameResultButton.swift in Sources */,

--- a/FindDict/FindDict.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FindDict/FindDict.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "8dd85aee02e39dd280c75eef88ffdb86eed4b07b",
+        "version" : "5.6.2"
+      }
+    },
+    {
       "identity" : "snapkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SnapKit/SnapKit.git",
@@ -12,7 +21,7 @@
     {
       "identity" : "then",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/devxoul/Then.git",
+      "location" : "https://github.com/devxoul/Then",
       "state" : {
         "branch" : "master",
         "revision" : "d41ef523faef0f911369f79c0b96815d9dbb6d7a"

--- a/FindDict/FindDict/Global/Extensions/UIImage+.swift
+++ b/FindDict/FindDict/Global/Extensions/UIImage+.swift
@@ -48,11 +48,24 @@ extension UIImage {
                                 bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue);
         context?.concatenate(CGAffineTransform(rotationAngle: 0))
         context?.concatenate(__CGAffineTransformMake( 1, 0, 0, -1, 0, CGFloat(height) )) //Flip Vertical
-//        context?.concatenate(__CGAffineTransformMake( -1.0, 0.0, 0.0, 1.0, CGFloat(width), 0.0)) //Flip Horizontal
+        //        context?.concatenate(__CGAffineTransformMake( -1.0, 0.0, 0.0, 1.0, CGFloat(width), 0.0)) //Flip Horizontal
         
         
         context?.draw(cgimage!, in: CGRect(x:0, y:0, width:CGFloat(width), height:CGFloat(height)));
         status = CVPixelBufferUnlockBaseAddress(pxbuffer!, CVPixelBufferLockFlags(rawValue: 0));
         return pxbuffer!;
         
-    }}
+    }
+    
+    func resizeImage() -> UIImage {
+        let width = UIScreen.main.bounds.width
+        let scale = width / self.size.width
+        let height = self.size.height * scale
+        UIGraphicsBeginImageContext(CGSize(width: width, height: height))
+        self.draw(in: CGRect(x: 0, y: 0, width: width, height: height))
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return newImage!
+    }
+    
+}

--- a/FindDict/FindDict/Global/Extensions/UIImageView+.swift
+++ b/FindDict/FindDict/Global/Extensions/UIImageView+.swift
@@ -1,0 +1,25 @@
+//
+//  UIImageVIew+.swift
+//  FindDict
+//
+//  Created by 김지민 on 2022/11/14.
+//
+
+import UIKit
+
+extension UIImageView {
+    func load(_ URLAddress: String) {
+        guard let url = URL(string: URLAddress) else {
+            return
+        }
+        DispatchQueue.global().async { [weak self] in
+            if let data = try? Data(contentsOf: url) {
+                if let image = UIImage(data: data) {
+                    DispatchQueue.main.async {
+                        self?.image = image.resizeImage()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/FindDict/FindDict/Info.plist
+++ b/FindDict/FindDict/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIAppFonts</key>
 	<array>
 		<string>NotoSans-Bold.ttf</string>

--- a/FindDict/FindDict/Model/HintResponseModel.swift
+++ b/FindDict/FindDict/Model/HintResponseModel.swift
@@ -8,11 +8,9 @@
 import Foundation
 
 struct HintResponseModel: Codable {
-    
-    let images: [String] = []
+    let images: [String]
 
     enum CodingKeys: String, CodingKey {
         case images = "images"
     }
 }
-

--- a/FindDict/FindDict/Network/APIManagers/WordAPI.swift
+++ b/FindDict/FindDict/Network/APIManagers/WordAPI.swift
@@ -40,18 +40,18 @@ class WordAPI: BaseAPI {
         }
 }
     /// [POST] 단어 추가
-    func postWord(body: CreateWordBodyModel,
-                    completion: @escaping (NetworkResult<Any>) -> (Void)) {
-        AFmanager.request(WordService.postWord(body: body)).responseData { response in
-            switch response.result {
-            case .success:
-                guard let statusCode = response.response?.statusCode else { return }
-                guard let data = response.data else { return }
-                let networkResult = self.judgeStatus(by: statusCode, data, CreateWordResponseModel.self)
-                completion(networkResult)
-            case .failure(let err):
-                print(err.localizedDescription)
-            }
-        }
-    }
+//    func postWord(body: CreateWordBodyModel,
+//                    completion: @escaping (NetworkResult<Any>) -> (Void)) {
+//        AFmanager.request(WordService.postWord(body: body)).responseData { response in
+//            switch response.result {
+//            case .success:
+//                guard let statusCode = response.response?.statusCode else { return }
+//                guard let data = response.data else { return }
+//                let networkResult = self.judgeStatus(by: statusCode, data, CreateWordResponseModel.self)
+//                completion(networkResult)
+//            case .failure(let err):
+//                print(err.localizedDescription)
+//            }
+//        }
+//    }
 }

--- a/FindDict/FindDict/Network/APIManagers/WordAPI.swift
+++ b/FindDict/FindDict/Network/APIManagers/WordAPI.swift
@@ -32,7 +32,7 @@ class WordAPI: BaseAPI {
             case .success:
                 guard let statusCode = response.response?.statusCode else { return }
                 guard let data = response.data else { return }
-                let networkResult = self.judgeStatus(by: statusCode, data, WordListResponseModel.self)
+                let networkResult = self.judgeStatus(by: statusCode, data, HintResponseModel.self)
                 completion(networkResult)
             case .failure(let err):
                 print(err.localizedDescription)

--- a/FindDict/FindDict/Network/Services/WordService.swift
+++ b/FindDict/FindDict/Network/Services/WordService.swift
@@ -10,7 +10,7 @@ import Alamofire
 enum WordService {
     case getWordList
     case getHint(search: String)
-    case postWord(body: CreateWordBodyModel)
+//    case postWord(body: CreateWordBodyModel)
 }
 
 extension WordService: TargetType {
@@ -20,8 +20,8 @@ extension WordService: TargetType {
             return "/word/list"
         case .getHint:
             return "/word"
-        case .postWord:
-            return "/word/new"
+//        case .postWord:
+//            return "/word/new"
         }
     }
     
@@ -31,8 +31,8 @@ extension WordService: TargetType {
             return .get
         case .getHint:
             return .get
-        case .postWord:
-            return .post
+//        case .postWord:
+//            return .post
         }
     }
     
@@ -42,8 +42,8 @@ extension WordService: TargetType {
             return .withToken
         case .getHint:
             return .withToken
-        case .postWord:
-            return .multiPartWithToken
+//        case .postWord:
+//            return .multiPartWithToken
         }
     }
     
@@ -53,8 +53,8 @@ extension WordService: TargetType {
             return .requestPlain
         case .getHint(let search):
             return .query(["search": search])
-        case .postWord(let body):
-            return .requestBody(["words": body.words])
+//        case .postWord(let body):
+//            return .requestBody(["words": body.words])
         }
     }
 }

--- a/FindDict/FindDict/Sources/Scences/Game/GameVC.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/GameVC.swift
@@ -74,6 +74,7 @@ class GameVC:ViewController {
     private lazy var wordTargets: [TargetListComponentView] = []{
         didSet{
             for wordTarget in wordTargets{
+                wordTarget.setDelegate(delegate: self)
                 targetListContainerView.addArrangedSubview(wordTarget)
             }
         }
@@ -135,11 +136,11 @@ class GameVC:ViewController {
         wordTargets = createdTargets
         
         // 네트워크 통신 테스트
-        let word = CreateWordBodyModel.Word(korean: "한글", english: "영어")
-        let word2 = CreateWordBodyModel.Word(korean: "한글2", english: "영어2")
-        let test = CreateWordBodyModel(words: [word, word2])
-    
-        requestPostWord(data: test)
+//        let word = CreateWordBodyModel.Word(korean: "한글", english: "영어")
+//        let word2 = CreateWordBodyModel.Word(korean: "한글2", english: "영어2")
+//        let test = CreateWordBodyModel(words: [word, word2])
+//    
+//        requestPostWord(data: test)
     }
     
     /// 인식된 객체마다 이에 맞는 버튼을 생성합니다.
@@ -211,6 +212,16 @@ class GameVC:ViewController {
     
 }
 
+// MARK: - DictionaryCardDelegate
+extension GameVC: TargetComponentViewDelegate {
+    func hintButtonClicked(korean: String) {
+        let hintModalVC = HintModalVC()
+        hintModalVC.setKoreanText(korean: korean)
+        hintModalVC.modalPresentationStyle = .overCurrentContext
+        self.present(hintModalVC, animated: true)
+    }
+}
+
 // MARK: - UI
 extension GameVC {
     func setLayout() {
@@ -280,19 +291,19 @@ extension GameVC {
 
 // MARK: - Network
 extension GameVC {
-    private func requestPostWord(data: CreateWordBodyModel) {
-        WordAPI.shared.postWord(body: data) {
-            networkResult in
-            switch networkResult {
-            case .success(let response):
-                if let res = response as? CreateWordResponseModel {
-                    print(res)
-                }
-            default:
-                self.makeAlert(title: MessageType.networkError.message)
-            }
-        }
-    }
+//    private func requestPostWord(data: CreateWordBodyModel) {
+//        WordAPI.shared.postWord(body: data) {
+//            networkResult in
+//            switch networkResult {
+//            case .success(let response):
+//                if let res = response as? CreateWordResponseModel {
+//                    print(res)
+//                }
+//            default:
+//                self.makeAlert(title: MessageType.networkError.message)
+//            }
+//        }
+//    }
     
 }
 

--- a/FindDict/FindDict/Sources/Scences/Game/HintModalVC.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/HintModalVC.swift
@@ -12,11 +12,22 @@ import Then
 
 class HintModalVC: UIViewController {
     // MARK: - Properties
+    private var images: [String] = [] {
+        didSet{
+            print(">>>>>>>>>>>>>>>",images)
+            hintImageView1.load(images[0])
+            hintImageView2.load(images[1])
+            hintImageView3.load(images[2])
+            hintImageView4.load(images[3])
+            //            hintImageView2.load(
+        }
+    }
     private var korean: String = "" {
         didSet{
             requestGetHint(search: korean)
         }
     }
+    
     private let modalView = UIView().then{
         $0.backgroundColor = .bgBeige
         $0.layer.shadowRadius = 4
@@ -87,7 +98,7 @@ class HintModalVC: UIViewController {
     func setKoreanText(korean: String){
         self.korean = korean
     }
-
+    
 }
 
 // MARK: - Network
@@ -97,20 +108,20 @@ extension HintModalVC {
             switch networkResult {
             case .success(let response):
                 if let res = response as? HintResponseModel {
-                    print(res)
+                    self.images = res.images
                     //                    UserToken.shared.accessToken = res.accessToken
-                    //                    self.carouselData = res
-                    //                    self.requestGetMumentForTodayData()
-                    // TODO: - 회원가입 성공 알러트 창 띄우기
-                    self.navigationController?.pushViewController(SignInVC(), animated: true)
+                } else {
+                    debugPrint(MessageType.modelErrorForDebug.message)
                 }
             default:
                 self.makeAlert(title: MessageType.networkError.message)
             }
         }
+        
     }
-    
 }
+
+
 // MARK: - UI
 extension HintModalVC {
     private func setLayout() {
@@ -128,7 +139,7 @@ extension HintModalVC {
         closeButton.snp.makeConstraints{
             $0.top.equalTo(modalView.snp.top).offset(16)
             $0.trailing.equalTo(modalView.snp.trailing).offset(-20)
-      
+            
         }
         imageStackView.snp.makeConstraints{
             $0.top.equalTo(modalView.snp.top).offset(75)

--- a/FindDict/FindDict/Sources/Scences/Game/HintModalVC.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/HintModalVC.swift
@@ -12,6 +12,11 @@ import Then
 
 class HintModalVC: UIViewController {
     // MARK: - Properties
+    private var korean: String = "" {
+        didSet{
+            requestGetHint(search: korean)
+        }
+    }
     private let modalView = UIView().then{
         $0.backgroundColor = .bgBeige
         $0.layer.shadowRadius = 4
@@ -19,23 +24,29 @@ class HintModalVC: UIViewController {
         $0.layer.shadowColor = UIColor.black.cgColor
         $0.layer.shadowOpacity = 0.25
     }
+    
     private let hintLabel = UILabel().then{
         $0.text = "HINT"
         $0.textColor = .black
         $0.font = .findDictH4R35
     }
+    
     private let closeButton = UIButton().then{
         $0.setImage(UIImage(named: "closeImage"), for: .normal)
     }
+    
     private let hintImageView1 = UIImageView().then{
         $0.image = UIImage(named: "globe")
     }
+    
     private let hintImageView2 = UIImageView().then{
         $0.image = UIImage(named: "globe")
     }
+    
     private let hintImageView3 = UIImageView().then{
         $0.image = UIImage(named: "globe")
     }
+    
     private let hintImageView4 = UIImageView().then{
         $0.image = UIImage(named: "globe")
     }
@@ -72,9 +83,34 @@ class HintModalVC: UIViewController {
             self.dismiss(animated: true, completion: nil)
         }
     }
+    
+    func setKoreanText(korean: String){
+        self.korean = korean
+    }
 
 }
 
+// MARK: - Network
+extension HintModalVC {
+    private func requestGetHint(search: String) {
+        WordAPI.shared.getHint(search: search){ networkResult in
+            switch networkResult {
+            case .success(let response):
+                if let res = response as? HintResponseModel {
+                    print(res)
+                    //                    UserToken.shared.accessToken = res.accessToken
+                    //                    self.carouselData = res
+                    //                    self.requestGetMumentForTodayData()
+                    // TODO: - 회원가입 성공 알러트 창 띄우기
+                    self.navigationController?.pushViewController(SignInVC(), animated: true)
+                }
+            default:
+                self.makeAlert(title: MessageType.networkError.message)
+            }
+        }
+    }
+    
+}
 // MARK: - UI
 extension HintModalVC {
     private func setLayout() {

--- a/FindDict/FindDict/Sources/Scences/Game/TargetListComponentView.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/TargetListComponentView.swift
@@ -9,8 +9,14 @@ import UIKit
 import SnapKit
 import Then
 
+
+protocol TargetComponentViewDelegate: AnyObject {
+    func hintButtonClicked(korean: String)
+}
+
 class TargetListComponentView: UIView {
     
+    private var delegate: TargetComponentViewDelegate?
     private let koreanButton = UIButton().then{
         if #available(iOS 15.0, *) {
             $0.configuration = .plain()
@@ -87,6 +93,7 @@ class TargetListComponentView: UIView {
     func setButtonActions(){
         koreanButton.press{
             print("힌트 보기")
+            self.delegate?.hintButtonClicked(korean: self.koreanButton.currentTitle ?? "버튼 레이블 오류")
         }
     }
     
@@ -99,6 +106,10 @@ class TargetListComponentView: UIView {
         englishLabel.text = englishLabelText
         koreanButton.backgroundColor = .buttonGray
     }
+    
+    func setDelegate(delegate: TargetComponentViewDelegate){
+            self.delegate = delegate
+        }
     
 }
 


### PR DESCRIPTION
## 작업한 내용
- 힌트 API 네트워크 연결
- 네트워크 통신 결과 UI에 반영

## PR Point
- 한국어 클릭 시 힌트 모달이 열리게 하는 것은 protocol, delegate를 이용했습니다. 
- 네트워크 통신 결과로 받아온 url 스트링값들은 UIImageView+, UIImage+ Extension 파일 코드를 사용하여 UIImageView에 적용하였습니다.

## 📸 스크린샷

https://user-images.githubusercontent.com/25932970/201653152-6d81fc7a-dce8-4239-94a4-dad3608c717b.mov




## 관련 이슈
- Resolved: #50 
