### PR TITLE
[FEAT] 단어 사진 확인하기 컬렉션 뷰 기본 이미지

### DIFF
--- a/FindDict/FindDict/Sources/Scences/Dictionary/DictionaryDetailVC.swift
+++ b/FindDict/FindDict/Sources/Scences/Dictionary/DictionaryDetailVC.swift
@@ -65,7 +65,7 @@ class DictionaryDetailVC: UIViewController{
     }
     
     // TODO: - 로딩 전 이미지 파인드딕트 이미지로 넣어두기
-    private var dataSource : [String] = ["https://finddict.s3.ap-northeast-2.amazonaws.com/test/1665054395307_%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202022-10-03%20%E1%84%8B%E1%85%A9%E1%84%92%E1%85%AE%2011.35.45.png","https://finddict.s3.ap-northeast-2.amazonaws.com/test/1665054314880_%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202022-10-03%20%E1%84%8B%E1%85%A9%E1%84%92%E1%85%AE%2010.17.12.png"]{
+    private var dataSource : [String] = ["https://finddict.s3.ap-northeast-2.amazonaws.com/test/1668622382989_launchScreen.png"]{
         didSet{
             self.increasedDataSource =  dataSource + dataSource + dataSource
         }


### PR DESCRIPTION
## 작업한 내용
- 단어 사진 확인하기 컬렉션 뷰 기본 이미지를 추가했습니다
- 네트워크 통신 결과 데이터 값이 받아오기 전 아래 사진이 보여지게 됩니다.

## PR Point
- postman 단어 생성으로 사진을 넣은 뒤 amazon s3에 저장된 이미지의 url을 가져와 넣었습니다.

## 📸 스크린샷
![Simulator Screen Shot - iPad Pro (11-inch) (4th generation) - 2022-11-17 at 03 15 54](https://user-images.githubusercontent.com/25932970/202264017-f4ff2673-34bf-4afe-ad33-1d09821a045f.png)

## 관련 이슈
- Resolved: #62 