### PR TITLE
[Feat] 버튼 테두리 안보이게, 레이블 투명

### DIFF
--- a/FindDict/FindDict.xcodeproj/project.pbxproj
+++ b/FindDict/FindDict.xcodeproj/project.pbxproj
@@ -93,7 +93,7 @@
 
 /* Begin PBXFileReference section */
 		4D0B1E1128E5A9A4007F16DB /* GameVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameVC.swift; sourceTree = "<group>"; };
-		4D0B1E1328E5AA2C007F16DB /* yolov5m.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; name = yolov5m.mlmodel; path = ../../../../../../../../Downloads/yolov5m.mlmodel; sourceTree = "<group>"; };
+		4D0B1E1328E5AA2C007F16DB /* yolov5m.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; name = yolov5m.mlmodel; path = ../../../../../../../Downloads/yolov5m.mlmodel; sourceTree = "<group>"; };
 		4D0B1E1528E5B213007F16DB /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		4D14BD6728E1B924002B2165 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
 		4D14BD6928E1C0F9002B2165 /* TextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TextField.swift; path = FindDict/Global/Extensions/TextField.swift; sourceTree = SOURCE_ROOT; };

--- a/FindDict/FindDict/Sources/Scences/Game/GameVC.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/GameVC.swift
@@ -148,34 +148,19 @@ final class GameVC: ViewController {
     
     private func createButton(prediction: VNRecognizedObjectObservation)-> UIButton {
         let buttonTitle: String? = prediction.label
-        let color: UIColor = labelColor(with: buttonTitle ?? "N/A")
-        
         let scale = CGAffineTransform.identity.scaledBy(x: buttonLayer.bounds.width, y: buttonLayer.bounds.height)
-        
         let bgRect = prediction.boundingBox.applying(scale)
         
         let button = UIButton(type: .custom).then {
             $0.frame = bgRect
-            $0.layer.borderColor = color.cgColor
             $0.backgroundColor = .systemBlue
-            $0.layer.borderWidth = 4
+            $0.layer.borderWidth = 0
             $0.backgroundColor = UIColor.clear
             $0.setTitle(buttonTitle, for: .normal)
+            $0.setTitleColor(.clear, for: .normal)
         }
         
         return button
-    }
-    
-    // TODO: - 버튼 위치 잘 잡고 나면 삭제할 프로퍼티
-    private var colors: [String : UIColor] = [:]
-    private func labelColor(with label: String) -> UIColor {
-        if let color = colors[label] {
-            return color
-        } else {
-            let color = UIColor(hue: .random(in: 0...1), saturation: 1, brightness: 1, alpha: 0.8)
-            colors[label] = color
-            return color
-        }
     }
     
     private func disableButtons(label: String){

--- a/FindDict/FindDict/Sources/Scences/Game/GameVC.swift
+++ b/FindDict/FindDict/Sources/Scences/Game/GameVC.swift
@@ -154,7 +154,6 @@ final class GameVC: ViewController {
         let button = UIButton(type: .custom).then {
             $0.frame = bgRect
             $0.backgroundColor = .systemBlue
-            $0.layer.borderWidth = 0
             $0.backgroundColor = UIColor.clear
             $0.setTitle(buttonTitle, for: .normal)
             $0.setTitleColor(.clear, for: .normal)


### PR DESCRIPTION
## 작업한 내용
- 버튼 테두리 삭제 
- 버튼 레이블 color: .clear로 변경

## PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 아직 완성뷰가 안나와서 게임 튜토리얼 뷰는 변경하지 않았습니다
```
    숨은 그림 찾기 게임하기
    "그림 속에 있는 물체들을 순서대로 찾아 클릭해보세요!\n\n 맞으면 동그라미, 틀리면 표시돼요\n\n 단어를 찾으면 그 다음 단어로 넘어갑니다"
    숨은 물체를 찾았을 때
    "정답을 클릭했을 때 물체의 영어 단어를 미국식/영국식/호주식 발음으로 들을 수 있어요"
    힌트
    "모르는 단어가 나왔을 때는 단어를 클릭해보세요!\n힌트를 볼 수 있어요\n\nX를 누르면 다시 게임으로 돌아갑니다."
    게임 종료
    "모든 단어를 찾으면 게임이 종료됩니다.\n\n다시 게임을 할 수도 있고, 단어장에 가서 게임한 단어들을 모아 볼 수 있어요"
     단어장
    "게임에 등장했던 단어들은 단어장 페이지에서 모아볼 수 있어요."
    단어 사진 보기
    "게임에 등장했던 물체의 사진들을 슬라이드로 넘겨보세요!\n\n발음도 다시 들을 수 있어요"
```
멘트는 위와 같이 쪼금 바꿔봤는데 더 추가할 내용 적어주시면 감사하겠습니다!
## 📸 스크린샷
<!-- gif or mp4 용량 제한 있음 -->

![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2022-12-08 at 16 55 45](https://user-images.githubusercontent.com/72034311/206390800-cb54edfb-4fc9-4c12-94b7-896edbf4c7ca.png)

## 관련 이슈
- Resolved: #88 

<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->